### PR TITLE
MGDOBR-25: create CD pipeline

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -3,6 +3,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'LICENSE'
+      - '**/.gitignore'
+      - '**.md'
+      - '**.adoc'
+      - '*.txt'
+      - '.github/*'
+      - 'kustomize/*'
+      
 jobs:
   event-bridge-build:
     env:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,8 +9,8 @@ on:
       - '**.md'
       - '**.adoc'
       - '*.txt'
-      - '.github/*'
-      - 'kustomize/*'
+      - '.github/**'
+      - 'kustomize/**'
       
 jobs:
   event-bridge-build:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
           CONTAINER_REGISTRY_USER: ${{ secrets.CONTAINER_REGISTRY_USER }}
-        run: echo "$CONTAINER_REGISTRY_PASSWORD" | docker login quay.io --username $CONTAINER_REGISTRY_USER --password-stdin
+        run: docker login quay.io --username $CONTAINER_REGISTRY_USER --password $CONTAINER_REGISTRY_PASSWORD
       - name: Build and Publish JVM Container
         shell: bash
         run: |

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,59 @@
+name: Event Bridge - CD
+on:
+  push:
+    branches:
+      - main
+jobs:
+  event-bridge-build:
+    env:
+      MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
+      OUTPUT_CONTAINER_NAME: quay.io/5733d9e2be6485d52ffa08870cabdee0/event-bridge-all-in-one:${{ github.sha }}
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    name: Publish JARs and Containers
+    steps:
+      - name: Disk space report before modification
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
+      # Inspired to maximize-build-space action https://github.com/easimon/maximize-build-space
+      - name: Free disk space (remove dotnet, android and haskell)
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+      - name: Disk space report after modification
+        shell: bash
+        run: |
+          echo "Available storage:"
+          df -h
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache Maven Packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+      - name: Build JARs
+        shell: bash
+        run: mvn --batch-mode package -Dmaven.test.skip=true -Dcheckstyle.skip
+      - name: Login to Container Registry
+        shell: bash
+        env:
+          CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+          CONTAINER_REGISTRY_USER: ${{ secrets.CONTAINER_REGISTRY_USER }}
+        run: echo "$CONTAINER_REGISTRY_PASSWORD" | docker login quay.io --username $CONTAINER_REGISTRY_USER --password-stdin
+      - name: Build and Publish JVM Container
+        shell: bash
+        run: |
+          docker build -f runner/src/main/docker/Dockerfile.jvm -t $OUTPUT_CONTAINER_NAME-jvm runner/
+          docker push $OUTPUT_CONTAINER_NAME-jvm
+          docker image rm -f $OUTPUT_CONTAINER_NAME-jvm
+#


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/MGDOBR-25

This PR aims to add the CD pipeline so to create a new docker image when a PR is merged into main. Since at the moment we have one simple application that contains multiple modules, the pipeline will only create one image called `event-bridge-all-in-one`. 

When the different modules will be moved to different and separated applications we will deprecate `event-bridge-all-in-one` and create ad-hoc images. 