### PR TITLE
[MGBOBR-6] Part 1: Manager-side API for adding Processor to a Bridge

### DIFF
--- a/executor/src/main/java/com/redhat/developer/executor/Executor.java
+++ b/executor/src/main/java/com/redhat/developer/executor/Executor.java
@@ -1,5 +1,7 @@
 package com.redhat.developer.executor;
 
-public class ExecutorAPI {
+public class Executor {
+
+
 
 }

--- a/executor/src/main/java/com/redhat/developer/executor/Executor.java
+++ b/executor/src/main/java/com/redhat/developer/executor/Executor.java
@@ -2,6 +2,4 @@ package com.redhat.developer.executor;
 
 public class Executor {
 
-
-
 }

--- a/infra/src/main/java/com/redhat/developer/infra/api/APIConstants.java
+++ b/infra/src/main/java/com/redhat/developer/infra/api/APIConstants.java
@@ -1,9 +1,19 @@
-package com.redhat.developer.manager.api;
+package com.redhat.developer.infra.api;
 
 /**
- * Some constants used for parameter naming and defaults for the API
+ * Some constants used for URL construction, parameter naming and defaults for the API
  */
 public class APIConstants {
+
+    /**
+     * Base Path for the user-facing API
+     */
+    public static final String USER_API_BASE_PATH = "/api/v1/bridges/";
+
+    /**
+     * Base Path for Shard facing API.
+     */
+    public static final String SHARD_API_BASE_PATH = "/api/v1/shard/bridges";
 
     /**
      * The page query parameter name

--- a/manager/src/main/java/com/redhat/developer/manager/BridgesServiceImpl.java
+++ b/manager/src/main/java/com/redhat/developer/manager/BridgesServiceImpl.java
@@ -66,7 +66,7 @@ public class BridgesServiceImpl implements BridgesService {
 
     @Override
     public ListResult<Bridge> getBridges(String customerId, int page, int pageSize) {
-        return bridgeDAO.listByCustomerId(customerId, page, pageSize);
+        return bridgeDAO.findByCustomerId(customerId, page, pageSize);
     }
 
     @Override

--- a/manager/src/main/java/com/redhat/developer/manager/ProcessorService.java
+++ b/manager/src/main/java/com/redhat/developer/manager/ProcessorService.java
@@ -1,0 +1,55 @@
+package com.redhat.developer.manager;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+
+import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
+import com.redhat.developer.manager.dao.BridgeDAO;
+import com.redhat.developer.manager.dao.ProcessorDAO;
+import com.redhat.developer.manager.exceptions.AlreadyExistingItemException;
+import com.redhat.developer.manager.exceptions.BridgeLifecycleException;
+import com.redhat.developer.manager.exceptions.ItemNotFoundException;
+import com.redhat.developer.manager.models.Bridge;
+import com.redhat.developer.manager.models.Processor;
+
+@ApplicationScoped
+public class ProcessorService {
+
+    @Inject
+    ProcessorDAO processorDAO;
+
+    @Inject
+    BridgeDAO bridgeDAO;
+
+    @Transactional
+    public Processor createProcessor(String customerId, String bridgeId, ProcessorRequest processorRequest) {
+        Bridge bridge = bridgeDAO.findByIdAndCustomerId(bridgeId, customerId);
+        if (bridge == null) {
+            throw new ItemNotFoundException("Bridge with id '" + bridgeId + "' does not exist for customer '" + customerId + "'");
+        }
+
+        if (BridgeStatus.AVAILABLE != bridge.getStatus()) {
+            /* We cannot deploy Processors to a Bridge that is not Available */
+            throw new BridgeLifecycleException("Bridge with id '" + bridge.getId() + "' for customer '" + customerId + "' is not in the '" + BridgeStatus.AVAILABLE + "' state.");
+        }
+
+        Processor p = processorDAO.findByBridgeIdAndName(bridgeId, processorRequest.getName());
+        if (p != null) {
+            throw new AlreadyExistingItemException("Processor with name '" + processorRequest.getName() + "' already exists for bridge with id '" + bridgeId + "' for customer '" + customerId + "'");
+        }
+
+        p = new Processor();
+        p.setName(processorRequest.getName());
+        p.setSubmittedAt(ZonedDateTime.now());
+        p.setStatus(BridgeStatus.REQUESTED);
+        bridge.addProcessor(p);
+        processorDAO.persist(p);
+        return p;
+    }
+}

--- a/manager/src/main/java/com/redhat/developer/manager/ProcessorService.java
+++ b/manager/src/main/java/com/redhat/developer/manager/ProcessorService.java
@@ -1,8 +1,6 @@
 package com.redhat.developer.manager;
 
 import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;

--- a/manager/src/main/java/com/redhat/developer/manager/api/internal/ShardBridgesSyncAPI.java
+++ b/manager/src/main/java/com/redhat/developer/manager/api/internal/ShardBridgesSyncAPI.java
@@ -16,12 +16,13 @@ import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.redhat.developer.infra.api.APIConstants;
 import com.redhat.developer.infra.dto.BridgeDTO;
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.manager.BridgesService;
 import com.redhat.developer.manager.models.Bridge;
 
-@Path("/api/v1/shard/bridges")
+@Path(APIConstants.SHARD_API_BASE_PATH)
 public class ShardBridgesSyncAPI {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ShardBridgesSyncAPI.class);

--- a/manager/src/main/java/com/redhat/developer/manager/api/models/requests/BridgeRequest.java
+++ b/manager/src/main/java/com/redhat/developer/manager/api/models/requests/BridgeRequest.java
@@ -1,10 +1,13 @@
 package com.redhat.developer.manager.api.models.requests;
 
+import javax.validation.constraints.NotEmpty;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.redhat.developer.manager.models.Bridge;
 
 public class BridgeRequest {
 
+    @NotEmpty(message = "Bridge name cannot be null or empty")
     @JsonProperty("name")
     private String name;
 

--- a/manager/src/main/java/com/redhat/developer/manager/api/models/requests/ProcessorRequest.java
+++ b/manager/src/main/java/com/redhat/developer/manager/api/models/requests/ProcessorRequest.java
@@ -1,0 +1,27 @@
+package com.redhat.developer.manager.api.models.requests;
+
+import javax.validation.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ProcessorRequest {
+
+    @NotEmpty(message = "Processor name cannot be null or empty")
+    @JsonProperty("name")
+    private String name;
+
+    public ProcessorRequest() {
+    }
+
+    public ProcessorRequest(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/manager/src/main/java/com/redhat/developer/manager/api/models/responses/ProcessorResponse.java
+++ b/manager/src/main/java/com/redhat/developer/manager/api/models/responses/ProcessorResponse.java
@@ -1,0 +1,98 @@
+package com.redhat.developer.manager.api.models.responses;
+
+import java.time.ZonedDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.redhat.developer.infra.dto.BridgeStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProcessorResponse {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("kind")
+    private final String kind = "Processor";
+
+    @JsonProperty("href")
+    private String href;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("bridge")
+    private BridgeResponse bridge;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")
+    @JsonProperty("submitted_at")
+    private ZonedDateTime submittedAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")
+    @JsonProperty("published_at")
+    private ZonedDateTime publishedAt;
+
+    @JsonProperty("status")
+    private BridgeStatus status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public BridgeResponse getBridge() {
+        return bridge;
+    }
+
+    public void setBridge(BridgeResponse bridge) {
+        this.bridge = bridge;
+    }
+
+    public ZonedDateTime getSubmittedAt() {
+        return submittedAt;
+    }
+
+    public void setSubmittedAt(ZonedDateTime submittedAt) {
+        this.submittedAt = submittedAt;
+    }
+
+    public ZonedDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(ZonedDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public BridgeStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(BridgeStatus status) {
+        this.status = status;
+    }
+}

--- a/manager/src/main/java/com/redhat/developer/manager/api/user/BridgesAPI.java
+++ b/manager/src/main/java/com/redhat/developer/manager/api/user/BridgesAPI.java
@@ -54,7 +54,7 @@ public class BridgesAPI {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getBridges(@DefaultValue(PAGE_DEFAULT) @Min(PAGE_MIN) @QueryParam(PAGE) int page,
-                               @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(PAGE_SIZE) int pageSize) {
+            @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(PAGE_SIZE) int pageSize) {
         ListResult<Bridge> bridges = bridgesService
                 .getBridges(customerIdResolver.resolveCustomerId(), page, pageSize);
 

--- a/manager/src/main/java/com/redhat/developer/manager/api/user/BridgesAPI.java
+++ b/manager/src/main/java/com/redhat/developer/manager/api/user/BridgesAPI.java
@@ -20,6 +20,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.redhat.developer.infra.api.APIConstants;
 import com.redhat.developer.manager.BridgesService;
 import com.redhat.developer.manager.CustomerIdResolver;
 import com.redhat.developer.manager.ProcessorService;
@@ -31,15 +32,15 @@ import com.redhat.developer.manager.models.Bridge;
 import com.redhat.developer.manager.models.ListResult;
 import com.redhat.developer.manager.models.Processor;
 
-import static com.redhat.developer.manager.api.APIConstants.PAGE;
-import static com.redhat.developer.manager.api.APIConstants.PAGE_DEFAULT;
-import static com.redhat.developer.manager.api.APIConstants.PAGE_MIN;
-import static com.redhat.developer.manager.api.APIConstants.PAGE_SIZE;
-import static com.redhat.developer.manager.api.APIConstants.SIZE_DEFAULT;
-import static com.redhat.developer.manager.api.APIConstants.SIZE_MAX;
-import static com.redhat.developer.manager.api.APIConstants.SIZE_MIN;
+import static com.redhat.developer.infra.api.APIConstants.PAGE;
+import static com.redhat.developer.infra.api.APIConstants.PAGE_DEFAULT;
+import static com.redhat.developer.infra.api.APIConstants.PAGE_MIN;
+import static com.redhat.developer.infra.api.APIConstants.PAGE_SIZE;
+import static com.redhat.developer.infra.api.APIConstants.SIZE_DEFAULT;
+import static com.redhat.developer.infra.api.APIConstants.SIZE_MAX;
+import static com.redhat.developer.infra.api.APIConstants.SIZE_MIN;
 
-@Path("/api/v1/bridges")
+@Path(APIConstants.USER_API_BASE_PATH)
 public class BridgesAPI {
 
     @Inject
@@ -81,7 +82,7 @@ public class BridgesAPI {
     }
 
     @GET
-    @Path("/{id}")
+    @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getBridge(@PathParam("id") @NotEmpty String id) {
         Bridge bridge = bridgesService.getBridge(id, customerIdResolver.resolveCustomerId());
@@ -89,18 +90,18 @@ public class BridgesAPI {
     }
 
     @DELETE
-    @Path("/{id}")
+    @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response deleteBridge(@PathParam("id") String id) {
         bridgesService.deleteBridge(id, customerIdResolver.resolveCustomerId());
         return Response.accepted().build();
     }
 
-    @Path("/{id}/processors")
+    @Path("{id}/processors")
     @POST
     public Response addProcessorToBridge(@PathParam("id") @NotEmpty String id, @Valid ProcessorRequest processorRequest) {
         String customerId = customerIdResolver.resolveCustomerId();
-        Processor processor = processorService.createProcessor(customerId, id, processorRequest);
+        Processor processor = processorService.createProcessor(id, customerId, processorRequest);
         return Response.status(Response.Status.CREATED).entity(processor.toResponse()).build();
     }
 }

--- a/manager/src/main/java/com/redhat/developer/manager/dao/BridgeDAO.java
+++ b/manager/src/main/java/com/redhat/developer/manager/dao/BridgeDAO.java
@@ -34,7 +34,7 @@ public class BridgeDAO implements PanacheRepositoryBase<Bridge, String> {
         return find("#BRIDGE.findByIdAndCustomerId", params).firstResult();
     }
 
-    public ListResult<Bridge> listByCustomerId(String customerId, int page, int pageSize) {
+    public ListResult<Bridge> findByCustomerId(String customerId, int page, int pageSize) {
         Parameters parameters = Parameters.with("customerId", customerId);
         long total = find("#BRIDGE.findByCustomerId", parameters).count();
         List<Bridge> bridges = find("#BRIDGE.findByCustomerId", parameters).page(page, pageSize).list();

--- a/manager/src/main/java/com/redhat/developer/manager/dao/ProcessorDAO.java
+++ b/manager/src/main/java/com/redhat/developer/manager/dao/ProcessorDAO.java
@@ -1,6 +1,5 @@
 package com.redhat.developer.manager.dao;
 
-import java.util.Arrays;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -8,6 +7,7 @@ import javax.transaction.Transactional;
 
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.manager.models.Processor;
+
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.Parameters;
 

--- a/manager/src/main/java/com/redhat/developer/manager/dao/ProcessorDAO.java
+++ b/manager/src/main/java/com/redhat/developer/manager/dao/ProcessorDAO.java
@@ -11,8 +11,6 @@ import com.redhat.developer.manager.models.Processor;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.Parameters;
 
-import static java.util.Arrays.asList;
-
 @ApplicationScoped
 @Transactional
 public class ProcessorDAO implements PanacheRepositoryBase<Processor, String> {
@@ -22,8 +20,8 @@ public class ProcessorDAO implements PanacheRepositoryBase<Processor, String> {
         return find("#PROCESSOR.findByBridgeIdAndName", p).firstResultOptional().orElse(null);
     }
 
-    public List<Processor> listProcessorsToDeployOrDelete(String bridgeId) {
-        Parameters p = Parameters.with(Processor.BRIDGE_ID_PARAM, bridgeId).and("statuses", asList(BridgeStatus.REQUESTED));
-        return find("#PROCESSOR.listByBridgeAndStatus", p).list();
+    public List<Processor> findByStatuses(String bridgeId, List<BridgeStatus> statuses) {
+        Parameters p = Parameters.with(Processor.BRIDGE_ID_PARAM, bridgeId).and("statuses", statuses);
+        return find("#PROCESSOR.findByBridgeAndStatus", p).list();
     }
 }

--- a/manager/src/main/java/com/redhat/developer/manager/dao/ProcessorDAO.java
+++ b/manager/src/main/java/com/redhat/developer/manager/dao/ProcessorDAO.java
@@ -1,0 +1,29 @@
+package com.redhat.developer.manager.dao;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Transactional;
+
+import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.models.Processor;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.quarkus.panache.common.Parameters;
+
+import static java.util.Arrays.asList;
+
+@ApplicationScoped
+@Transactional
+public class ProcessorDAO implements PanacheRepositoryBase<Processor, String> {
+
+    public Processor findByBridgeIdAndName(String bridgeId, String name) {
+        Parameters p = Parameters.with(Processor.NAME_PARAM, name).and(Processor.BRIDGE_ID_PARAM, bridgeId);
+        return find("#PROCESSOR.findByBridgeIdAndName", p).firstResultOptional().orElse(null);
+    }
+
+    public List<Processor> listProcessorsToDeployOrDelete(String bridgeId) {
+        Parameters p = Parameters.with(Processor.BRIDGE_ID_PARAM, bridgeId).and("statuses", asList(BridgeStatus.REQUESTED));
+        return find("#PROCESSOR.listByBridgeAndStatus", p).list();
+    }
+}

--- a/manager/src/main/java/com/redhat/developer/manager/exceptions/BridgeLifecycleException.java
+++ b/manager/src/main/java/com/redhat/developer/manager/exceptions/BridgeLifecycleException.java
@@ -1,0 +1,19 @@
+package com.redhat.developer.manager.exceptions;
+
+import javax.ws.rs.core.Response;
+
+public class BridgeLifecycleException extends EventBridgeManagerException {
+
+    public BridgeLifecycleException(String message) {
+        super(message);
+    }
+
+    public BridgeLifecycleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return Response.Status.BAD_REQUEST.getStatusCode();
+    }
+}

--- a/manager/src/main/java/com/redhat/developer/manager/exceptions/ItemNotFoundException.java
+++ b/manager/src/main/java/com/redhat/developer/manager/exceptions/ItemNotFoundException.java
@@ -14,6 +14,6 @@ public class ItemNotFoundException extends EventBridgeManagerException {
 
     @Override
     public int getStatusCode() {
-        return Response.Status.BAD_REQUEST.getStatusCode();
+        return Response.Status.NOT_FOUND.getStatusCode();
     }
 }

--- a/manager/src/main/java/com/redhat/developer/manager/models/Bridge.java
+++ b/manager/src/main/java/com/redhat/developer/manager/models/Bridge.java
@@ -33,7 +33,7 @@ import com.redhat.developer.manager.api.models.responses.BridgeResponse;
                 query = "from Bridge where customer_id=:customerId order by submitted_at desc"),
 })
 @Entity
-@Table(name = "BRIDGE", uniqueConstraints = {@UniqueConstraint(columnNames = {"name", "customer_id"})})
+@Table(name = "BRIDGE", uniqueConstraints = { @UniqueConstraint(columnNames = { "name", "customer_id" }) })
 public class Bridge {
 
     @Id

--- a/manager/src/main/java/com/redhat/developer/manager/models/Bridge.java
+++ b/manager/src/main/java/com/redhat/developer/manager/models/Bridge.java
@@ -1,15 +1,20 @@
 package com.redhat.developer.manager.models;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
@@ -28,7 +33,7 @@ import com.redhat.developer.manager.api.models.responses.BridgeResponse;
                 query = "from Bridge where customer_id=:customerId order by submitted_at desc"),
 })
 @Entity
-@Table(name = "BRIDGE", uniqueConstraints = { @UniqueConstraint(columnNames = { "name", "customer_id" }) })
+@Table(name = "BRIDGE", uniqueConstraints = {@UniqueConstraint(columnNames = {"name", "customer_id"})})
 public class Bridge {
 
     @Id
@@ -53,7 +58,20 @@ public class Bridge {
     @Enumerated(EnumType.STRING)
     private BridgeStatus status;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "bridge", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<Processor> processors = new ArrayList<>();
+
     public Bridge() {
+    }
+
+    public void addProcessor(Processor processor) {
+        this.processors.add(processor);
+        processor.setBridge(this);
+    }
+
+    public void removeProcessor(Processor processor) {
+        this.processors.remove(processor);
+        processor.setBridge(null);
     }
 
     public Bridge(String name) {
@@ -114,6 +132,14 @@ public class Bridge {
 
     public void setCustomerId(String customerId) {
         this.customerId = customerId;
+    }
+
+    public List<Processor> getProcessors() {
+        return processors;
+    }
+
+    public void setProcessors(List<Processor> processors) {
+        this.processors = processors;
     }
 
     public BridgeDTO toDTO() {

--- a/manager/src/main/java/com/redhat/developer/manager/models/Bridge.java
+++ b/manager/src/main/java/com/redhat/developer/manager/models/Bridge.java
@@ -1,23 +1,20 @@
 package com.redhat.developer.manager.models;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+import com.redhat.developer.infra.api.APIConstants;
 import com.redhat.developer.infra.dto.BridgeDTO;
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.manager.api.models.responses.BridgeResponse;
@@ -58,20 +55,7 @@ public class Bridge {
     @Enumerated(EnumType.STRING)
     private BridgeStatus status;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "bridge", orphanRemoval = true, cascade = CascadeType.ALL)
-    private List<Processor> processors = new ArrayList<>();
-
     public Bridge() {
-    }
-
-    public void addProcessor(Processor processor) {
-        this.processors.add(processor);
-        processor.setBridge(this);
-    }
-
-    public void removeProcessor(Processor processor) {
-        this.processors.remove(processor);
-        processor.setBridge(null);
     }
 
     public Bridge(String name) {
@@ -134,14 +118,6 @@ public class Bridge {
         this.customerId = customerId;
     }
 
-    public List<Processor> getProcessors() {
-        return processors;
-    }
-
-    public void setProcessors(List<Processor> processors) {
-        this.processors = processors;
-    }
-
     public BridgeDTO toDTO() {
         BridgeDTO dto = new BridgeDTO();
         dto.setId(id);
@@ -171,8 +147,29 @@ public class Bridge {
         response.setSubmittedAt(submittedAt);
         response.setPublishedAt(publishedAt);
         response.setStatus(status);
-        response.setHref("/api/v1/bridges/" + id);
+        response.setHref(APIConstants.USER_API_BASE_PATH + id);
 
         return response;
+    }
+
+    /*
+     * See: https://vladmihalcea.com/how-to-implement-equals-and-hashcode-using-the-jpa-entity-identifier/
+     * In the context of JPA equality, our id is our unique business key as we generate it via UUID.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Bridge bridge = (Bridge) o;
+        return id.equals(bridge.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/manager/src/main/java/com/redhat/developer/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/developer/manager/models/Processor.java
@@ -1,6 +1,7 @@
 package com.redhat.developer.manager.models;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -14,6 +15,7 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Version;
 
+import com.redhat.developer.infra.api.APIConstants;
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.manager.api.models.responses.ProcessorResponse;
 
@@ -114,10 +116,31 @@ public class Processor {
         processorResponse.setSubmittedAt(submittedAt);
 
         if (this.bridge != null) {
-            processorResponse.setHref("/api/v1/bridges/" + bridge.getId() + "/processors/" + id);
+            processorResponse.setHref(APIConstants.USER_API_BASE_PATH + bridge.getId() + "/processors/" + id);
             processorResponse.setBridge(this.bridge.toResponse());
         }
 
         return processorResponse;
+    }
+
+    /*
+     * See: https://vladmihalcea.com/how-to-implement-equals-and-hashcode-using-the-jpa-entity-identifier/
+     * In the context of JPA equality, our id is our unique business key as we generate it via UUID.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Processor processor = (Processor) o;
+        return id.equals(processor.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/manager/src/main/java/com/redhat/developer/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/developer/manager/models/Processor.java
@@ -20,7 +20,7 @@ import com.redhat.developer.manager.api.models.responses.ProcessorResponse;
 @NamedQueries({
         @NamedQuery(name = "PROCESSOR.findByBridgeIdAndName",
                 query = "from Processor p where p.name=:name and p.bridge.id=:bridgeId"),
-        @NamedQuery(name = "PROCESSOR.listByBridgeAndStatus",
+        @NamedQuery(name = "PROCESSOR.findByBridgeAndStatus",
                 query = "from Processor p where p.status in (:statuses) and p.bridge.id=:bridgeId")
 })
 @Entity

--- a/manager/src/main/java/com/redhat/developer/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/developer/manager/models/Processor.java
@@ -1,0 +1,123 @@
+package com.redhat.developer.manager.models;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Version;
+
+import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.api.models.responses.ProcessorResponse;
+
+@NamedQueries({
+        @NamedQuery(name = "PROCESSOR.findByBridgeIdAndName",
+                query = "from Processor p where p.name=:name and p.bridge.id=:bridgeId"),
+        @NamedQuery(name = "PROCESSOR.listByBridgeAndStatus",
+                query = "from Processor p where p.status in (:statuses) and p.bridge.id=:bridgeId")
+})
+@Entity
+public class Processor {
+
+    public static final String NAME_PARAM = "name";
+
+    public static final String BRIDGE_ID_PARAM = "bridgeId";
+
+    @Id
+    private String id = UUID.randomUUID().toString();
+
+    @Column(nullable = false, name = "name")
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Bridge bridge;
+
+    @Version
+    private long version;
+
+    @Column(name = "submitted_at", updatable = false, nullable = false, columnDefinition = "TIMESTAMP")
+    private ZonedDateTime submittedAt;
+
+    @Column(name = "published_at", columnDefinition = "TIMESTAMP")
+    private ZonedDateTime publishedAt;
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private BridgeStatus status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Bridge getBridge() {
+        return bridge;
+    }
+
+    public void setBridge(Bridge bridge) {
+        this.bridge = bridge;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public ZonedDateTime getSubmittedAt() {
+        return submittedAt;
+    }
+
+    public void setSubmittedAt(ZonedDateTime submittedAt) {
+        this.submittedAt = submittedAt;
+    }
+
+    public ZonedDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(ZonedDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public BridgeStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(BridgeStatus status) {
+        this.status = status;
+    }
+
+    public ProcessorResponse toResponse() {
+
+        ProcessorResponse processorResponse = new ProcessorResponse();
+        processorResponse.setId(id);
+        processorResponse.setName(name);
+        processorResponse.setStatus(status);
+        processorResponse.setPublishedAt(publishedAt);
+        processorResponse.setSubmittedAt(submittedAt);
+
+        if (this.bridge != null) {
+            processorResponse.setHref("/api/v1/bridges/" + bridge.getId() + "/processors/" + id);
+            processorResponse.setBridge(this.bridge.toResponse());
+        }
+
+        return processorResponse;
+    }
+}

--- a/manager/src/main/resources/db/migration/0.1/V0.1.2__create_processor.sql
+++ b/manager/src/main/resources/db/migration/0.1/V0.1.2__create_processor.sql
@@ -1,0 +1,12 @@
+create table PROCESSOR
+(
+    id                 varchar(255) NOT NULL PRIMARY KEY,
+    bridge_id          varchar(255) NOT NULL,
+    name               varchar(255) NOT NULL,
+    submitted_at       timestamp    NOT NULL,
+    published_at       timestamp,
+    status             varchar(255),
+    version            integer NOT NULL default 0,
+    unique (bridge_id, name),
+    constraint fk_bridge foreign key (bridge_id) references BRIDGE (id)
+);

--- a/manager/src/test/java/com/redhat/developer/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/ProcessorServiceTest.java
@@ -1,0 +1,83 @@
+package com.redhat.developer.manager;
+
+import java.time.ZonedDateTime;
+
+import javax.inject.Inject;
+
+import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
+import com.redhat.developer.manager.dao.BridgeDAO;
+import com.redhat.developer.manager.exceptions.AlreadyExistingItemException;
+import com.redhat.developer.manager.exceptions.BridgeLifecycleException;
+import com.redhat.developer.manager.exceptions.ItemNotFoundException;
+import com.redhat.developer.manager.models.Bridge;
+import com.redhat.developer.manager.models.Processor;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@QuarkusTest
+public class ProcessorServiceTest {
+
+    @Inject
+    BridgeDAO bridgeDAO;
+
+    @Inject
+    ProcessorService processorService;
+
+    private Bridge createBridge(BridgeStatus status) {
+
+        Bridge b = new Bridge();
+        b.setName("foo-" + System.currentTimeMillis());
+        b.setCustomerId("bar");
+        b.setStatus(status);
+        b.setSubmittedAt(ZonedDateTime.now());
+        b.setPublishedAt(ZonedDateTime.now());
+        bridgeDAO.persist(b);
+        return b;
+    }
+
+    @Test
+    public void createProcessor_bridgeNotActive() {
+        Bridge b = createBridge(BridgeStatus.PROVISIONING);
+        assertThrows(BridgeLifecycleException.class, () -> processorService.createProcessor(b.getCustomerId(), b.getId(), new ProcessorRequest()));
+    }
+
+    @Test
+    public void createProcessor_bridgeDoesNotExist() {
+        assertThrows(ItemNotFoundException.class, () -> processorService.createProcessor("foo", "bar", new ProcessorRequest()));
+    }
+
+    @Test
+    public void createProcessor_processorWithSameNameAlreadyExists() {
+
+        Bridge b = createBridge(BridgeStatus.AVAILABLE);
+        ProcessorRequest r = new ProcessorRequest();
+        r.setName("My Processor");
+
+        Processor processor = processorService.createProcessor(b.getCustomerId(), b.getId(), r);
+        assertThat(processor, is(notNullValue()));
+
+        assertThrows(AlreadyExistingItemException.class, () -> processorService.createProcessor(b.getCustomerId(), b.getId(), r));
+    }
+
+    @Test
+    public void createProcessor() {
+        Bridge b = createBridge(BridgeStatus.AVAILABLE);
+        ProcessorRequest r = new ProcessorRequest();
+        r.setName("My Processor");
+
+        Processor processor = processorService.createProcessor(b.getCustomerId(), b.getId(), r);
+        assertThat(processor, is(notNullValue()));
+
+        assertThat(processor.getBridge().getId(), equalTo(b.getId()));
+        assertThat(processor.getName(), equalTo(r.getName()));
+        assertThat(processor.getStatus(), equalTo(BridgeStatus.REQUESTED));
+        assertThat(processor.getSubmittedAt(), is(notNullValue()));
+    }
+}

--- a/manager/src/test/java/com/redhat/developer/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/ProcessorServiceTest.java
@@ -36,7 +36,7 @@ public class ProcessorServiceTest {
 
         Bridge b = new Bridge();
         b.setName("foo-" + System.currentTimeMillis());
-        b.setCustomerId("bar");
+        b.setCustomerId(TestConstants.DEFAULT_CUSTOMER_ID);
         b.setStatus(status);
         b.setSubmittedAt(ZonedDateTime.now());
         b.setPublishedAt(ZonedDateTime.now());
@@ -47,34 +47,32 @@ public class ProcessorServiceTest {
     @Test
     public void createProcessor_bridgeNotActive() {
         Bridge b = createBridge(BridgeStatus.PROVISIONING);
-        assertThrows(BridgeLifecycleException.class, () -> processorService.createProcessor(b.getCustomerId(), b.getId(), new ProcessorRequest()));
+        assertThrows(BridgeLifecycleException.class, () -> processorService.createProcessor(b.getId(), b.getCustomerId(), new ProcessorRequest()));
     }
 
     @Test
     public void createProcessor_bridgeDoesNotExist() {
-        assertThrows(ItemNotFoundException.class, () -> processorService.createProcessor("foo", "bar", new ProcessorRequest()));
+        assertThrows(ItemNotFoundException.class, () -> processorService.createProcessor("foo", TestConstants.DEFAULT_CUSTOMER_ID, new ProcessorRequest()));
     }
 
     @Test
     public void createProcessor_processorWithSameNameAlreadyExists() {
 
         Bridge b = createBridge(BridgeStatus.AVAILABLE);
-        ProcessorRequest r = new ProcessorRequest();
-        r.setName("My Processor");
+        ProcessorRequest r = new ProcessorRequest("My Processor");
 
-        Processor processor = processorService.createProcessor(b.getCustomerId(), b.getId(), r);
+        Processor processor = processorService.createProcessor(b.getId(), b.getCustomerId(), r);
         assertThat(processor, is(notNullValue()));
 
-        assertThrows(AlreadyExistingItemException.class, () -> processorService.createProcessor(b.getCustomerId(), b.getId(), r));
+        assertThrows(AlreadyExistingItemException.class, () -> processorService.createProcessor(b.getId(), b.getCustomerId(), r));
     }
 
     @Test
     public void createProcessor() {
         Bridge b = createBridge(BridgeStatus.AVAILABLE);
-        ProcessorRequest r = new ProcessorRequest();
-        r.setName("My Processor");
+        ProcessorRequest r = new ProcessorRequest("My Processor");
 
-        Processor processor = processorService.createProcessor(b.getCustomerId(), b.getId(), r);
+        Processor processor = processorService.createProcessor(b.getId(), b.getCustomerId(), r);
         assertThat(processor, is(notNullValue()));
 
         assertThat(processor.getBridge().getId(), equalTo(b.getId()));

--- a/manager/src/test/java/com/redhat/developer/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/ProcessorServiceTest.java
@@ -4,6 +4,8 @@ import java.time.ZonedDateTime;
 
 import javax.inject.Inject;
 
+import org.junit.jupiter.api.Test;
+
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
 import com.redhat.developer.manager.dao.BridgeDAO;
@@ -12,8 +14,8 @@ import com.redhat.developer.manager.exceptions.BridgeLifecycleException;
 import com.redhat.developer.manager.exceptions.ItemNotFoundException;
 import com.redhat.developer.manager.models.Bridge;
 import com.redhat.developer.manager.models.Processor;
+
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/manager/src/test/java/com/redhat/developer/manager/api/internal/ShardBridgesSyncAPITest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/api/internal/ShardBridgesSyncAPITest.java
@@ -103,6 +103,6 @@ public class ShardBridgesSyncAPITest {
         bridge.setStatus(BridgeStatus.DELETED);
         TestUtils.updateBridge(bridge).then().statusCode(200);
 
-        TestUtils.getBridge(bridge.getId()).then().statusCode(400);
+        TestUtils.getBridge(bridge.getId()).then().statusCode(404);
     }
 }

--- a/manager/src/test/java/com/redhat/developer/manager/api/user/BridgesAPITest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/api/user/BridgesAPITest.java
@@ -2,27 +2,25 @@ package com.redhat.developer.manager.api.user;
 
 import javax.inject.Inject;
 
-import com.redhat.developer.infra.dto.BridgeDTO;
-import com.redhat.developer.manager.CustomerIdResolver;
-import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
-import com.redhat.developer.manager.api.models.responses.ProcessorResponse;
-import io.restassured.RestAssured;
-import io.restassured.filter.log.ResponseLoggingFilter;
-import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.developer.infra.dto.BridgeDTO;
 import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.CustomerIdResolver;
 import com.redhat.developer.manager.TestConstants;
 import com.redhat.developer.manager.api.models.requests.BridgeRequest;
+import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
 import com.redhat.developer.manager.api.models.responses.BridgeListResponse;
 import com.redhat.developer.manager.api.models.responses.BridgeResponse;
+import com.redhat.developer.manager.api.models.responses.ProcessorResponse;
 import com.redhat.developer.manager.utils.DatabaseManagerUtils;
 import com.redhat.developer.manager.utils.TestUtils;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/manager/src/test/java/com/redhat/developer/manager/dao/BridgeDAOTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/dao/BridgeDAOTest.java
@@ -70,7 +70,7 @@ public class BridgeDAOTest {
         Bridge secondBridge = buildBridge("mySecondBridgeId", "mySecondBridgeName");
         bridgeDAO.persist(secondBridge);
 
-        ListResult<Bridge> retrievedBridges = bridgeDAO.listByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, TestConstants.DEFAULT_PAGE, TestConstants.DEFAULT_PAGE_SIZE);
+        ListResult<Bridge> retrievedBridges = bridgeDAO.findByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, TestConstants.DEFAULT_PAGE, TestConstants.DEFAULT_PAGE_SIZE);
         Assertions.assertNotNull(retrievedBridges);
         Assertions.assertEquals(2, retrievedBridges.getSize());
         Assertions.assertEquals(2, retrievedBridges.getTotal());
@@ -89,7 +89,7 @@ public class BridgeDAOTest {
             bridgeDAO.persist(bridge);
         }
 
-        ListResult<Bridge> retrievedBridges = bridgeDAO.listByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 0, 2);
+        ListResult<Bridge> retrievedBridges = bridgeDAO.findByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 0, 2);
         Assertions.assertNotNull(retrievedBridges);
         Assertions.assertEquals(2, retrievedBridges.getSize());
         Assertions.assertEquals(10, retrievedBridges.getTotal());
@@ -97,7 +97,7 @@ public class BridgeDAOTest {
         Assertions.assertEquals("9", retrievedBridges.getItems().get(0).getId());
         Assertions.assertEquals("8", retrievedBridges.getItems().get(1).getId());
 
-        retrievedBridges = bridgeDAO.listByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 1, 2);
+        retrievedBridges = bridgeDAO.findByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 1, 2);
         Assertions.assertNotNull(retrievedBridges);
         Assertions.assertEquals(2, retrievedBridges.getSize());
         Assertions.assertEquals(10, retrievedBridges.getTotal());
@@ -105,7 +105,7 @@ public class BridgeDAOTest {
         Assertions.assertEquals("7", retrievedBridges.getItems().get(0).getId());
         Assertions.assertEquals("6", retrievedBridges.getItems().get(1).getId());
 
-        retrievedBridges = bridgeDAO.listByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 4, 2);
+        retrievedBridges = bridgeDAO.findByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 4, 2);
         Assertions.assertNotNull(retrievedBridges);
         Assertions.assertEquals(2, retrievedBridges.getSize());
         Assertions.assertEquals(10, retrievedBridges.getTotal());
@@ -113,7 +113,7 @@ public class BridgeDAOTest {
         Assertions.assertEquals("1", retrievedBridges.getItems().get(0).getId());
         Assertions.assertEquals("0", retrievedBridges.getItems().get(1).getId());
 
-        retrievedBridges = bridgeDAO.listByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 5, 2);
+        retrievedBridges = bridgeDAO.findByCustomerId(TestConstants.DEFAULT_CUSTOMER_ID, 5, 2);
         Assertions.assertNotNull(retrievedBridges);
         Assertions.assertEquals(0, retrievedBridges.getSize());
         Assertions.assertEquals(10, retrievedBridges.getTotal());

--- a/manager/src/test/java/com/redhat/developer/manager/dao/ProcessorDAOTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/dao/ProcessorDAOTest.java
@@ -1,0 +1,86 @@
+package com.redhat.developer.manager.dao;
+
+import java.time.ZonedDateTime;
+
+import javax.inject.Inject;
+
+import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.models.Bridge;
+import com.redhat.developer.manager.models.Processor;
+import com.redhat.developer.manager.utils.DatabaseManagerUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+public class ProcessorDAOTest {
+
+    @Inject
+    ProcessorDAO processorDAO;
+
+    @Inject
+    BridgeDAO bridgeDAO;
+
+    @Inject
+    DatabaseManagerUtils databaseManagerUtils;
+
+    @BeforeEach
+    public void before() {
+        databaseManagerUtils.cleanDatabase();
+    }
+
+    private Processor createProcessor(Bridge bridge) {
+        Processor p = new Processor();
+        bridge.addProcessor(p);
+        p.setName("foo");
+        p.setStatus(BridgeStatus.REQUESTED);
+        p.setSubmittedAt(ZonedDateTime.now());
+        p.setPublishedAt(ZonedDateTime.now());
+        processorDAO.persist(p);
+        return p;
+    }
+
+    private Bridge createBridge() {
+        Bridge b = new Bridge();
+        b.setName("foo-" + System.currentTimeMillis());
+        b.setCustomerId("bar");
+        b.setStatus(BridgeStatus.REQUESTED);
+        b.setSubmittedAt(ZonedDateTime.now());
+        b.setPublishedAt(ZonedDateTime.now());
+        bridgeDAO.persist(b);
+        return b;
+    }
+
+    @Test
+    public void findByBridgeIdAndName_noMatchingBridgeId() {
+        Bridge b = createBridge();
+        Processor p = createProcessor(b);
+
+        assertThat(processorDAO.findByBridgeIdAndName("doesNotExist", p.getName()), is(nullValue()));
+    }
+
+    @Test
+    public void findByBridgeIdAndName_noMatchingProcessorName() {
+        Bridge b = createBridge();
+        createProcessor(b);
+
+        assertThat(processorDAO.findByBridgeIdAndName(b.getId(), "doesNotExist"), is(nullValue()));
+    }
+
+    @Test
+    public void findByBridgeIdAndName() {
+        Bridge b = createBridge();
+        Processor p = createProcessor(b);
+
+        Processor byBridgeIdAndName = processorDAO.findByBridgeIdAndName(b.getId(), p.getName());
+        assertThat(byBridgeIdAndName, is(notNullValue()));
+        assertThat(byBridgeIdAndName.getName(), equalTo(p.getName()));
+        assertThat(byBridgeIdAndName.getBridge().getId(), equalTo(b.getId()));
+    }
+}

--- a/manager/src/test/java/com/redhat/developer/manager/dao/ProcessorDAOTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/dao/ProcessorDAOTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.TestConstants;
 import com.redhat.developer.manager.models.Bridge;
 import com.redhat.developer.manager.models.Processor;
 import com.redhat.developer.manager.utils.DatabaseManagerUtils;
@@ -44,7 +45,7 @@ public class ProcessorDAOTest {
 
     private Processor createProcessor(Bridge bridge, String name) {
         Processor p = new Processor();
-        bridge.addProcessor(p);
+        p.setBridge(bridge);
         p.setName(name);
         p.setStatus(BridgeStatus.REQUESTED);
         p.setSubmittedAt(ZonedDateTime.now());
@@ -56,7 +57,7 @@ public class ProcessorDAOTest {
     private Bridge createBridge() {
         Bridge b = new Bridge();
         b.setName("foo-" + System.currentTimeMillis());
-        b.setCustomerId("bar");
+        b.setCustomerId(TestConstants.DEFAULT_CUSTOMER_ID);
         b.setStatus(BridgeStatus.REQUESTED);
         b.setSubmittedAt(ZonedDateTime.now());
         b.setPublishedAt(ZonedDateTime.now());
@@ -96,7 +97,7 @@ public class ProcessorDAOTest {
     public void findByStatuses() {
 
         Bridge b = createBridge();
-        Processor p = createProcessor(b, "foo");
+        createProcessor(b, "foo");
 
         Processor q = createProcessor(b, "bob");
         q.setStatus(BridgeStatus.AVAILABLE);

--- a/manager/src/test/java/com/redhat/developer/manager/dao/ProcessorDAOTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/dao/ProcessorDAOTest.java
@@ -4,13 +4,15 @@ import java.time.ZonedDateTime;
 
 import javax.inject.Inject;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.manager.models.Bridge;
 import com.redhat.developer.manager.models.Processor;
 import com.redhat.developer.manager.utils.DatabaseManagerUtils;
+
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/manager/src/test/java/com/redhat/developer/manager/models/ProcessorTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/models/ProcessorTest.java
@@ -1,0 +1,46 @@
+package com.redhat.developer.manager.models;
+
+import java.time.ZonedDateTime;
+
+import com.redhat.developer.infra.dto.BridgeStatus;
+import com.redhat.developer.manager.api.models.responses.ProcessorResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ProcessorTest {
+
+    @Test
+    public void toResponse() {
+
+        Bridge b = new Bridge();
+        b.setPublishedAt(ZonedDateTime.now());
+        b.setCustomerId("bar");
+        b.setStatus(BridgeStatus.AVAILABLE);
+        b.setName("bridgerton");
+        b.setSubmittedAt(ZonedDateTime.now());
+        b.setEndpoint("https://bridge.redhat.com");
+
+        Processor p = new Processor();
+        p.setName("foo");
+        p.setStatus(BridgeStatus.AVAILABLE);
+        p.setPublishedAt(ZonedDateTime.now());
+        p.setSubmittedAt(ZonedDateTime.now());
+        b.addProcessor(p);
+
+        ProcessorResponse r = p.toResponse();
+        assertThat(r, is(notNullValue()));
+
+        assertThat(r.getHref(), equalTo("/api/v1/bridges/" + b.getId() + "/processors/" + p.getId()));
+        assertThat(r.getName(), equalTo(p.getName()));
+        assertThat(r.getStatus(), equalTo(p.getStatus()));
+        assertThat(r.getId(), equalTo(p.getId()));
+        assertThat(r.getSubmittedAt(), equalTo(p.getSubmittedAt()));
+        assertThat(r.getPublishedAt(), equalTo(p.getPublishedAt()));
+        assertThat(r.getKind(), equalTo("Processor"));
+        assertThat(r.getBridge(), is(notNullValue()));
+    }
+}

--- a/manager/src/test/java/com/redhat/developer/manager/models/ProcessorTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/models/ProcessorTest.java
@@ -2,9 +2,10 @@ package com.redhat.developer.manager.models;
 
 import java.time.ZonedDateTime;
 
+import org.junit.jupiter.api.Test;
+
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.manager.api.models.responses.ProcessorResponse;
-import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/manager/src/test/java/com/redhat/developer/manager/models/ProcessorTest.java
+++ b/manager/src/test/java/com/redhat/developer/manager/models/ProcessorTest.java
@@ -30,7 +30,7 @@ public class ProcessorTest {
         p.setStatus(BridgeStatus.AVAILABLE);
         p.setPublishedAt(ZonedDateTime.now());
         p.setSubmittedAt(ZonedDateTime.now());
-        b.addProcessor(p);
+        p.setBridge(b);
 
         ProcessorResponse r = p.toResponse();
         assertThat(r, is(notNullValue()));

--- a/manager/src/test/java/com/redhat/developer/manager/utils/DatabaseManagerUtils.java
+++ b/manager/src/test/java/com/redhat/developer/manager/utils/DatabaseManagerUtils.java
@@ -2,6 +2,7 @@ package com.redhat.developer.manager.utils;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.transaction.Transactional;
 
 import com.redhat.developer.manager.dao.BridgeDAO;
 
@@ -19,9 +20,11 @@ public class DatabaseManagerUtils {
     BridgeDAO bridgeDAO;
 
     /**
-     * Call the `deleteAll` method of all the DAOs injected so to clean up the database entirely.
+     * Completely non performant way to cascade the delete of all bridges to their Processors. Performance
+     * doesn't really matter as this is only used in a testing scenario.
      */
+    @Transactional
     public void cleanDatabase() {
-        bridgeDAO.deleteAll();
+        bridgeDAO.listAll().stream().forEach(bridgeDAO::delete);
     }
 }

--- a/manager/src/test/java/com/redhat/developer/manager/utils/DatabaseManagerUtils.java
+++ b/manager/src/test/java/com/redhat/developer/manager/utils/DatabaseManagerUtils.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 
 import com.redhat.developer.manager.dao.BridgeDAO;
+import com.redhat.developer.manager.dao.ProcessorDAO;
 
 /**
  * This bean must be injected in every test class that uses the database.
@@ -19,12 +20,15 @@ public class DatabaseManagerUtils {
     @Inject
     BridgeDAO bridgeDAO;
 
+    @Inject
+    ProcessorDAO processorDAO;
+
     /**
-     * Completely non performant way to cascade the delete of all bridges to their Processors. Performance
-     * doesn't really matter as this is only used in a testing scenario.
+     * Clean everything from the DB. Processors must be deleted before bridges.
      */
     @Transactional
     public void cleanDatabase() {
-        bridgeDAO.listAll().stream().forEach(bridgeDAO::delete);
+        processorDAO.deleteAll();
+        bridgeDAO.deleteAll();
     }
 }

--- a/manager/src/test/java/com/redhat/developer/manager/utils/TestUtils.java
+++ b/manager/src/test/java/com/redhat/developer/manager/utils/TestUtils.java
@@ -2,8 +2,8 @@ package com.redhat.developer.manager.utils;
 
 import com.redhat.developer.infra.dto.BridgeDTO;
 import com.redhat.developer.manager.api.models.requests.BridgeRequest;
-
 import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
+
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;

--- a/manager/src/test/java/com/redhat/developer/manager/utils/TestUtils.java
+++ b/manager/src/test/java/com/redhat/developer/manager/utils/TestUtils.java
@@ -3,52 +3,52 @@ package com.redhat.developer.manager.utils;
 import com.redhat.developer.infra.dto.BridgeDTO;
 import com.redhat.developer.manager.api.models.requests.BridgeRequest;
 
+import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
 
 import static io.restassured.RestAssured.given;
 
 public class TestUtils {
 
-    public static Response getBridges() {
+    private static RequestSpecification jsonRequest() {
         return given()
                 .filter(new ResponseLoggingFilter())
                 .contentType(ContentType.JSON)
-                .when()
+                .when();
+    }
+
+    public static Response getBridges() {
+        return jsonRequest()
                 .get("/api/v1/bridges");
     }
 
     public static Response getBridge(String id) {
-        return given()
-                .filter(new ResponseLoggingFilter())
-                .contentType(ContentType.JSON)
-                .when()
+        return jsonRequest()
                 .get("/api/v1/bridges/" + id);
     }
 
+    public static Response addProcessorToBridge(String bridgeId, ProcessorRequest p) {
+        return jsonRequest()
+                .body(p)
+                .post("/api/v1/bridges/" + bridgeId + "/processors/");
+    }
+
     public static Response createBridge(BridgeRequest request) {
-        return given()
-                .filter(new ResponseLoggingFilter())
-                .contentType(ContentType.JSON)
-                .when()
+        return jsonRequest()
                 .body(request)
                 .post("/api/v1/bridges");
     }
 
     public static Response getBridgesToDeploy() {
-        return given()
-                .filter(new ResponseLoggingFilter())
-                .contentType(ContentType.JSON)
-                .when()
+        return jsonRequest()
                 .get("/api/v1/shard/bridges/toDeploy");
     }
 
     public static Response updateBridge(BridgeDTO bridgeDTO) {
-        return given()
-                .filter(new ResponseLoggingFilter())
-                .contentType(ContentType.JSON)
-                .when()
+        return jsonRequest()
                 .body(bridgeDTO)
                 .post("/api/v1/shard/bridges/toDeploy");
     }

--- a/manager/src/test/java/com/redhat/developer/manager/utils/TestUtils.java
+++ b/manager/src/test/java/com/redhat/developer/manager/utils/TestUtils.java
@@ -1,5 +1,6 @@
 package com.redhat.developer.manager.utils;
 
+import com.redhat.developer.infra.api.APIConstants;
 import com.redhat.developer.infra.dto.BridgeDTO;
 import com.redhat.developer.manager.api.models.requests.BridgeRequest;
 import com.redhat.developer.manager.api.models.requests.ProcessorRequest;
@@ -22,39 +23,39 @@ public class TestUtils {
 
     public static Response getBridges() {
         return jsonRequest()
-                .get("/api/v1/bridges");
+                .get(APIConstants.USER_API_BASE_PATH);
     }
 
     public static Response getBridge(String id) {
         return jsonRequest()
-                .get("/api/v1/bridges/" + id);
+                .get(APIConstants.USER_API_BASE_PATH + id);
     }
 
     public static Response addProcessorToBridge(String bridgeId, ProcessorRequest p) {
         return jsonRequest()
                 .body(p)
-                .post("/api/v1/bridges/" + bridgeId + "/processors/");
+                .post(APIConstants.USER_API_BASE_PATH + bridgeId + "/processors/");
     }
 
     public static Response createBridge(BridgeRequest request) {
         return jsonRequest()
                 .body(request)
-                .post("/api/v1/bridges");
+                .post(APIConstants.USER_API_BASE_PATH);
     }
 
     public static Response deleteBridge(String id) {
         return jsonRequest()
-                .delete("/api/v1/bridges/" + id);
+                .delete(APIConstants.USER_API_BASE_PATH + id);
     }
 
     public static Response getBridgesToDeployOrDelete() {
         return jsonRequest()
-                .get("/api/v1/shard/bridges");
+                .get(APIConstants.SHARD_API_BASE_PATH);
     }
 
     public static Response updateBridge(BridgeDTO bridgeDTO) {
         return jsonRequest()
                 .body(bridgeDTO)
-                .put("/api/v1/shard/bridges");
+                .put(APIConstants.SHARD_API_BASE_PATH);
     }
 }

--- a/shard/src/main/java/com/redhat/developer/shard/ManagerSyncService.java
+++ b/shard/src/main/java/com/redhat/developer/shard/ManagerSyncService.java
@@ -10,4 +10,6 @@ public interface ManagerSyncService {
     Uni<HttpResponse<Buffer>> notifyBridgeStatusChange(BridgeDTO bridgeDTO);
 
     Uni<Object> fetchAndProcessBridgesFromManager();
+
+
 }

--- a/shard/src/main/java/com/redhat/developer/shard/ManagerSyncServiceImpl.java
+++ b/shard/src/main/java/com/redhat/developer/shard/ManagerSyncServiceImpl.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.developer.infra.api.APIConstants;
 import com.redhat.developer.infra.dto.BridgeDTO;
 import com.redhat.developer.infra.dto.BridgeStatus;
 import com.redhat.developer.shard.exceptions.DeserializationException;
@@ -47,12 +48,12 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
     @Override
     public Uni<HttpResponse<Buffer>> notifyBridgeStatusChange(BridgeDTO bridgeDTO) {
         LOGGER.info("[shard] Notifying manager about the new status of the Bridge '{}'", bridgeDTO.getId());
-        return webClientManager.put("/api/v1/shard/bridges").sendJson(bridgeDTO);
+        return webClientManager.put(APIConstants.SHARD_API_BASE_PATH).sendJson(bridgeDTO);
     }
 
     @Override
     public Uni<Object> fetchAndProcessBridgesToDeployOrDeleteFromManager() {
-        return webClientManager.get("/api/v1/shard/bridges").send()
+        return webClientManager.get(APIConstants.SHARD_API_BASE_PATH).send()
                 .onItem().transform(x -> deserializeBridges(x.bodyAsString()))
                 .onItem().transformToUni(x -> Uni.createFrom().item(
                         x.stream()


### PR DESCRIPTION
This PR adds an additional endpoint to our API to add support for adding a Processor to a Bridge. The supported endpoint is `/api/v1/bridges/{id}/processors`. A Processor can be created on the given Bridge instance by `POST`-ing a request to this endpoint.

The shard side of the implementation is deliberately excluded from this PR. That will be in a follow-on PR.

Other minor changes in this PR include:

- Ensuring we return a HTTP 201 Created Response code from our API in response to POST requests as per guidelines


