### PR TITLE
[MGDOBR-9] API to allow user to GET details of a Processor

### DIFF
--- a/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorService.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorService.java
@@ -27,6 +27,17 @@ public class ProcessorService {
     @Inject
     BridgesService bridgesService;
 
+    public Processor getProcessor(String processorId, String bridgeId, String customerId) {
+
+        Bridge bridge = bridgesService.getBridge(bridgeId, customerId);
+        Processor processor = processorDAO.findByIdBridgeIdAndCustomerId(processorId, bridge.getId(), bridge.getCustomerId());
+        if (processor == null) {
+            throw new ItemNotFoundException(String.format("Processor with id '%s' does not exist on Bridge '%s' for customer '%s'", processorId, bridgeId, customerId));
+        }
+
+        return processor;
+    }
+
     public Processor createProcessor(String bridgeId, String customerId, ProcessorRequest processorRequest) {
         Bridge bridge = bridgesService.getBridge(bridgeId, customerId);
         checkBridgeInActiveStatus(bridge);

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/user/BridgesAPI.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/user/BridgesAPI.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
@@ -23,14 +22,11 @@ import javax.ws.rs.core.Response;
 import com.redhat.service.bridge.infra.api.APIConstants;
 import com.redhat.service.bridge.manager.BridgesService;
 import com.redhat.service.bridge.manager.CustomerIdResolver;
-import com.redhat.service.bridge.manager.ProcessorService;
 import com.redhat.service.bridge.manager.api.models.requests.BridgeRequest;
-import com.redhat.service.bridge.manager.api.models.requests.ProcessorRequest;
 import com.redhat.service.bridge.manager.api.models.responses.BridgeListResponse;
 import com.redhat.service.bridge.manager.api.models.responses.BridgeResponse;
 import com.redhat.service.bridge.manager.models.Bridge;
 import com.redhat.service.bridge.manager.models.ListResult;
-import com.redhat.service.bridge.manager.models.Processor;
 
 import static com.redhat.service.bridge.infra.api.APIConstants.PAGE;
 import static com.redhat.service.bridge.infra.api.APIConstants.PAGE_DEFAULT;
@@ -48,9 +44,6 @@ public class BridgesAPI {
 
     @Inject
     BridgesService bridgesService;
-
-    @Inject
-    ProcessorService processorService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -95,13 +88,5 @@ public class BridgesAPI {
     public Response deleteBridge(@PathParam("id") String id) {
         bridgesService.deleteBridge(id, customerIdResolver.resolveCustomerId());
         return Response.accepted().build();
-    }
-
-    @Path("{id}/processors")
-    @POST
-    public Response addProcessorToBridge(@PathParam("id") @NotEmpty String id, @Valid ProcessorRequest processorRequest) {
-        String customerId = customerIdResolver.resolveCustomerId();
-        Processor processor = processorService.createProcessor(id, customerId, processorRequest);
-        return Response.status(Response.Status.CREATED).entity(processor.toResponse()).build();
     }
 }

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/user/ProcessorsAPI.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/user/ProcessorsAPI.java
@@ -1,0 +1,45 @@
+package com.redhat.service.bridge.manager.api.user;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.redhat.service.bridge.infra.api.APIConstants;
+import com.redhat.service.bridge.manager.CustomerIdResolver;
+import com.redhat.service.bridge.manager.ProcessorService;
+import com.redhat.service.bridge.manager.api.models.requests.ProcessorRequest;
+import com.redhat.service.bridge.manager.models.Processor;
+
+@Path(APIConstants.USER_API_BASE_PATH)
+@Produces(MediaType.APPLICATION_JSON)
+public class ProcessorsAPI {
+
+    @Inject
+    ProcessorService processorService;
+
+    @Inject
+    CustomerIdResolver customerIdResolver;
+
+    @GET
+    @Path("{bridgeId}/processors/{processorId}")
+    public Response getProcessor(@NotEmpty @PathParam("bridgeId") String bridgeId, @NotEmpty @PathParam("processorId") String processorId) {
+        String customerId = customerIdResolver.resolveCustomerId();
+        Processor processor = processorService.getProcessor(processorId, bridgeId, customerId);
+        return Response.ok(processor.toResponse()).build();
+    }
+
+    @POST
+    @Path("{bridgeId}/processors")
+    public Response addProcessorToBridge(@PathParam("bridgeId") @NotEmpty String bridgeId, @Valid ProcessorRequest processorRequest) {
+        String customerId = customerIdResolver.resolveCustomerId();
+        Processor processor = processorService.createProcessor(bridgeId, customerId, processorRequest);
+        return Response.status(Response.Status.CREATED).entity(processor.toResponse()).build();
+    }
+}

--- a/manager/src/main/java/com/redhat/service/bridge/manager/dao/ProcessorDAO.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/dao/ProcessorDAO.java
@@ -6,6 +6,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.transaction.Transactional;
 
 import com.redhat.service.bridge.infra.dto.BridgeStatus;
+import com.redhat.service.bridge.manager.models.Bridge;
 import com.redhat.service.bridge.manager.models.Processor;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
@@ -18,6 +19,15 @@ public class ProcessorDAO implements PanacheRepositoryBase<Processor, String> {
     public Processor findByBridgeIdAndName(String bridgeId, String name) {
         Parameters p = Parameters.with(Processor.NAME_PARAM, name).and(Processor.BRIDGE_ID_PARAM, bridgeId);
         return find("#PROCESSOR.findByBridgeIdAndName", p).firstResultOptional().orElse(null);
+    }
+
+    public Processor findByIdBridgeIdAndCustomerId(String id, String bridgeId, String customerId) {
+
+        Parameters p = Parameters.with(Processor.ID_PARAM, id)
+                .and(Processor.BRIDGE_ID_PARAM, bridgeId)
+                .and(Bridge.CUSTOMER_ID_PARAM, customerId);
+
+        return find("#PROCESSOR.findByIdBridgeIdAndCustomerId", p).firstResultOptional().orElse(null);
     }
 
     public List<Processor> findByStatuses(List<BridgeStatus> statuses) {

--- a/manager/src/main/java/com/redhat/service/bridge/manager/models/Bridge.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/models/Bridge.java
@@ -33,6 +33,8 @@ import com.redhat.service.bridge.manager.api.models.responses.BridgeResponse;
 @Table(name = "BRIDGE", uniqueConstraints = { @UniqueConstraint(columnNames = { "name", "customer_id" }) })
 public class Bridge {
 
+    public static final String CUSTOMER_ID_PARAM = "customerId";
+
     @Id
     private String id = UUID.randomUUID().toString();
 

--- a/manager/src/main/java/com/redhat/service/bridge/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/models/Processor.java
@@ -24,10 +24,14 @@ import com.redhat.service.bridge.manager.api.models.responses.ProcessorResponse;
         @NamedQuery(name = "PROCESSOR.findByBridgeIdAndName",
                 query = "from Processor p where p.name=:name and p.bridge.id=:bridgeId"),
         @NamedQuery(name = "PROCESSOR.findByStatus",
-                query = "from Processor p join fetch p.bridge where p.status in (:statuses) and p.bridge.status='AVAILABLE'")
+                query = "from Processor p join fetch p.bridge where p.status in (:statuses) and p.bridge.status='AVAILABLE'"),
+        @NamedQuery(name = "PROCESSOR.findByIdBridgeIdAndCustomerId",
+                query = "from Processor p join fetch p.bridge where p.id=:id and (p.bridge.id=:bridgeId and p.bridge.customerId=:customerId)")
 })
 @Entity
 public class Processor {
+
+    public static final String ID_PARAM = "id";
 
     public static final String NAME_PARAM = "name";
 

--- a/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
@@ -157,4 +157,42 @@ public class ProcessorServiceTest {
 
         assertThrows(ItemNotFoundException.class, () -> processorService.updateProcessorStatus(processor));
     }
+
+    @Test
+    public void getProcessor() {
+
+        Bridge b = createBridge(BridgeStatus.AVAILABLE);
+        ProcessorRequest r = new ProcessorRequest("My Processor");
+
+        Processor processor = processorService.createProcessor(b.getId(), b.getCustomerId(), r);
+        assertThat(processor, is(notNullValue()));
+
+        Processor found = processorService.getProcessor(processor.getId(), b.getId(), b.getCustomerId());
+        assertThat(found, is(notNullValue()));
+        assertThat(found.getId(), equalTo(processor.getId()));
+        assertThat(found.getBridge().getId(), equalTo(b.getId()));
+        assertThat(found.getBridge().getCustomerId(), equalTo(b.getCustomerId()));
+    }
+
+    @Test
+    public void getProcessor_bridgeDoesNotExist() {
+        Bridge b = createBridge(BridgeStatus.AVAILABLE);
+        ProcessorRequest r = new ProcessorRequest("My Processor");
+
+        Processor processor = processorService.createProcessor(b.getId(), b.getCustomerId(), r);
+        assertThat(processor, is(notNullValue()));
+
+        assertThrows(ItemNotFoundException.class, () -> processorService.getProcessor(processor.getId(), "doesNotExist", b.getCustomerId()));
+    }
+
+    @Test
+    public void getProcessor_processorDoesNotExist() {
+        Bridge b = createBridge(BridgeStatus.AVAILABLE);
+        ProcessorRequest r = new ProcessorRequest("My Processor");
+
+        Processor processor = processorService.createProcessor(b.getId(), b.getCustomerId(), r);
+        assertThat(processor, is(notNullValue()));
+
+        assertThrows(ItemNotFoundException.class, () -> processorService.getProcessor("doesNotExist", b.getId(), b.getCustomerId()));
+    }
 }

--- a/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import com.redhat.service.bridge.infra.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.dto.BridgeStatus;
-import com.redhat.service.bridge.manager.CustomerIdResolver;
 import com.redhat.service.bridge.manager.TestConstants;
 import com.redhat.service.bridge.manager.api.models.requests.BridgeRequest;
 import com.redhat.service.bridge.manager.api.models.requests.ProcessorRequest;
@@ -28,9 +27,6 @@ public class ProcessorAPITest {
     @Inject
     DatabaseManagerUtils databaseManagerUtils;
 
-    @Inject
-    CustomerIdResolver customerIdResolver;
-
     private BridgeResponse createBridge() {
         BridgeRequest r = new BridgeRequest(TestConstants.DEFAULT_BRIDGE_NAME);
         BridgeResponse bridgeResponse = TestUtils.createBridge(r).as(BridgeResponse.class);
@@ -43,7 +39,7 @@ public class ProcessorAPITest {
         BridgeDTO dto = new BridgeDTO();
         dto.setId(bridgeResponse.getId());
         dto.setStatus(BridgeStatus.AVAILABLE);
-        dto.setCustomerId(customerIdResolver.resolveCustomerId());
+        dto.setCustomerId(TestConstants.DEFAULT_CUSTOMER_ID);
         dto.setEndpoint("https://foo.bridges.redhat.com");
 
         Response deployment = TestUtils.updateBridge(dto);

--- a/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
@@ -1,0 +1,127 @@
+package com.redhat.service.bridge.manager.api.user;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.service.bridge.infra.dto.BridgeDTO;
+import com.redhat.service.bridge.infra.dto.BridgeStatus;
+import com.redhat.service.bridge.manager.CustomerIdResolver;
+import com.redhat.service.bridge.manager.TestConstants;
+import com.redhat.service.bridge.manager.api.models.requests.BridgeRequest;
+import com.redhat.service.bridge.manager.api.models.requests.ProcessorRequest;
+import com.redhat.service.bridge.manager.api.models.responses.BridgeResponse;
+import com.redhat.service.bridge.manager.api.models.responses.ProcessorResponse;
+import com.redhat.service.bridge.manager.utils.DatabaseManagerUtils;
+import com.redhat.service.bridge.manager.utils.TestUtils;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+public class ProcessorAPITest {
+
+    @Inject
+    DatabaseManagerUtils databaseManagerUtils;
+
+    @Inject
+    CustomerIdResolver customerIdResolver;
+
+    private BridgeResponse createBridge() {
+        BridgeRequest r = new BridgeRequest(TestConstants.DEFAULT_BRIDGE_NAME);
+        BridgeResponse bridgeResponse = TestUtils.createBridge(r).as(BridgeResponse.class);
+        return bridgeResponse;
+    }
+
+    private BridgeResponse createAndDeployBridge() {
+        BridgeResponse bridgeResponse = createBridge();
+
+        BridgeDTO dto = new BridgeDTO();
+        dto.setId(bridgeResponse.getId());
+        dto.setStatus(BridgeStatus.AVAILABLE);
+        dto.setCustomerId(customerIdResolver.resolveCustomerId());
+        dto.setEndpoint("https://foo.bridges.redhat.com");
+
+        Response deployment = TestUtils.updateBridge(dto);
+        assertThat(deployment.getStatusCode(), equalTo(200));
+        return bridgeResponse;
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        databaseManagerUtils.cleanDatabase();
+    }
+
+    @Test
+    public void getProcessor() {
+        BridgeResponse bridgeResponse = createAndDeployBridge();
+
+        Response response = TestUtils.addProcessorToBridge(bridgeResponse.getId(), new ProcessorRequest("myProcessor"));
+        assertThat(response.getStatusCode(), equalTo(201));
+
+        ProcessorResponse pr = response.as(ProcessorResponse.class);
+        ProcessorResponse found = TestUtils.getProcessor(bridgeResponse.getId(), pr.getId()).as(ProcessorResponse.class);
+
+        assertThat(found.getId(), equalTo(pr.getId()));
+        assertThat(found.getBridge().getId(), equalTo(bridgeResponse.getId()));
+    }
+
+    @Test
+    public void getProcessor_processorDoesNotExist() {
+        BridgeResponse bridgeResponse = createAndDeployBridge();
+
+        Response response = TestUtils.addProcessorToBridge(bridgeResponse.getId(), new ProcessorRequest("myProcessor"));
+        assertThat(response.getStatusCode(), equalTo(201));
+
+        Response found = TestUtils.getProcessor(bridgeResponse.getId(), "doesNotExist");
+        assertThat(found.getStatusCode(), equalTo(404));
+    }
+
+    @Test
+    public void getProcessor_bridgeDoesNotExist() {
+        BridgeResponse bridgeResponse = createAndDeployBridge();
+
+        ProcessorResponse response = TestUtils.addProcessorToBridge(bridgeResponse.getId(), new ProcessorRequest("myProcessor")).as(ProcessorResponse.class);
+
+        Response found = TestUtils.getProcessor("doesNotExist", response.getId());
+        assertThat(found.getStatusCode(), equalTo(404));
+    }
+
+    @Test
+    public void addProcessorToBridge() {
+
+        BridgeResponse bridgeResponse = createAndDeployBridge();
+
+        Response response = TestUtils.addProcessorToBridge(bridgeResponse.getId(), new ProcessorRequest("myProcessor"));
+        assertThat(response.getStatusCode(), equalTo(201));
+
+        ProcessorResponse processorResponse = response.as(ProcessorResponse.class);
+        assertThat(processorResponse.getName(), equalTo("myProcessor"));
+        assertThat(processorResponse.getBridge().getId(), equalTo(bridgeResponse.getId()));
+    }
+
+    @Test
+    public void addProcessorToBridge_bridgeDoesNotExist() {
+
+        Response response = TestUtils.addProcessorToBridge("foo", new ProcessorRequest("myProcessor"));
+        assertThat(response.getStatusCode(), equalTo(404));
+    }
+
+    @Test
+    public void addProcessorToBridge_bridgeNotInAvailableStatus() {
+
+        BridgeResponse bridgeResponse = createBridge();
+        Response response = TestUtils.addProcessorToBridge(bridgeResponse.getId(), new ProcessorRequest("myProcessor"));
+        assertThat(response.getStatusCode(), equalTo(400));
+    }
+
+    @Test
+    public void addProcessorToBridge_noNameSuppliedForProcessor() {
+        Response response = TestUtils.addProcessorToBridge(TestConstants.DEFAULT_BRIDGE_NAME, new ProcessorRequest());
+        assertThat(response.getStatusCode(), equalTo(400));
+    }
+}

--- a/manager/src/test/java/com/redhat/service/bridge/manager/dao/ProcessorDAOTest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/dao/ProcessorDAOTest.java
@@ -111,4 +111,23 @@ public class ProcessorDAOTest {
         assertThat(processors, hasSize(2));
         processors.stream().forEach((px) -> assertThat(px.getName(), in(asList("bob", "frank"))));
     }
+
+    @Test
+    public void findByIdBridgeIdAndCustomerId() {
+        Bridge b = createBridge();
+        Processor p = createProcessor(b, "foo");
+
+        Processor found = processorDAO.findByIdBridgeIdAndCustomerId(p.getId(), b.getId(), b.getCustomerId());
+        assertThat(found, is(notNullValue()));
+        assertThat(found.getId(), equalTo(p.getId()));
+    }
+
+    @Test
+    public void findByIdBridgeIdAndCustomerId_doesNotExist() {
+        Bridge b = createBridge();
+        createProcessor(b, "foo");
+
+        Processor found = processorDAO.findByIdBridgeIdAndCustomerId("doesntExist", b.getId(), b.getCustomerId());
+        assertThat(found, is(nullValue()));
+    }
 }

--- a/manager/src/test/java/com/redhat/service/bridge/manager/utils/TestUtils.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/utils/TestUtils.java
@@ -32,6 +32,11 @@ public class TestUtils {
                 .get(APIConstants.USER_API_BASE_PATH + id);
     }
 
+    public static Response getProcessor(String bridgeId, String processorId) {
+        return jsonRequest()
+                .get(APIConstants.USER_API_BASE_PATH + bridgeId + "/processors/" + processorId);
+    }
+
     public static Response addProcessorToBridge(String bridgeId, ProcessorRequest p) {
         return jsonRequest()
                 .body(p)


### PR DESCRIPTION
This PR adds the `/api/v1/bridges/{id}/processors/{processorId}` endpoint. This allows a user to retrieve details of a Processor that they have deployed to their Bridge and see if it is in the `AVAILABLE` state i.e is it processing Events sent to the Bridge.

Couple of other things to note:

- I'm not yet able to add to the Integration Test suite without the ability to delete a Processor, which will be done in another story (https://issues.redhat.com/browse/MGDOBR-8)
- Listing of the Processors on a bridge is also done as another story (https://issues.redhat.com/browse/MGDOBR-7)