### PR TITLE
[MGDOBR-7] Add the ability to list processors on a bridge

### DIFF
--- a/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorService.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorService.java
@@ -15,6 +15,7 @@ import com.redhat.service.bridge.manager.exceptions.AlreadyExistingItemException
 import com.redhat.service.bridge.manager.exceptions.BridgeLifecycleException;
 import com.redhat.service.bridge.manager.exceptions.ItemNotFoundException;
 import com.redhat.service.bridge.manager.models.Bridge;
+import com.redhat.service.bridge.manager.models.ListResult;
 import com.redhat.service.bridge.manager.models.Processor;
 
 @Transactional
@@ -39,9 +40,7 @@ public class ProcessorService {
     }
 
     public Processor createProcessor(String bridgeId, String customerId, ProcessorRequest processorRequest) {
-        Bridge bridge = bridgesService.getBridge(bridgeId, customerId);
-        checkBridgeInActiveStatus(bridge);
-
+        Bridge bridge = getAvailableBridge(bridgeId, customerId);
         Processor p = processorDAO.findByBridgeIdAndName(bridgeId, processorRequest.getName());
         if (p != null) {
             throw new AlreadyExistingItemException("Processor with name '" + processorRequest.getName() + "' already exists for bridge with id '" + bridgeId + "' for customer '" + customerId + "'");
@@ -60,11 +59,14 @@ public class ProcessorService {
         return processorDAO.findByStatuses(statuses);
     }
 
-    private void checkBridgeInActiveStatus(Bridge bridge) {
+    private Bridge getAvailableBridge(String bridgeId, String customerId) {
+        Bridge bridge = bridgesService.getBridge(bridgeId, customerId);
         if (BridgeStatus.AVAILABLE != bridge.getStatus()) {
             /* We cannot deploy Processors to a Bridge that is not Available */
             throw new BridgeLifecycleException(String.format("Bridge with id '%s' for customer '%s' is not in the '%s' state.", bridge.getId(), bridge.getCustomerId(), BridgeStatus.AVAILABLE));
         }
+
+        return bridge;
     }
 
     public Processor updateProcessorStatus(ProcessorDTO processorDTO) {
@@ -75,5 +77,10 @@ public class ProcessorService {
         }
         p.setStatus(processorDTO.getStatus());
         return p;
+    }
+
+    public ListResult<Processor> getProcessors(String bridgeId, String customerId, int page, int size) {
+        Bridge bridge = getAvailableBridge(bridgeId, customerId);
+        return processorDAO.findByBridgeIdAndCustomerId(bridge.getId(), bridge.getCustomerId(), page, size);
     }
 }

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorListResponse.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorListResponse.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ProcessorListResponse extends ListResponse {
 
     @JsonProperty("kind")
-    private String kind = "BridgeList";
+    private String kind = "ProcessorList";
 
     @JsonProperty("items")
     private List<ProcessorResponse> items = new ArrayList<>();

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorListResponse.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorListResponse.java
@@ -1,0 +1,33 @@
+package com.redhat.service.bridge.manager.api.models.responses;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProcessorListResponse extends ListResponse {
+
+    @JsonProperty("kind")
+    private String kind = "BridgeList";
+
+    @JsonProperty("items")
+    private List<ProcessorResponse> items = new ArrayList<>();
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    public List<ProcessorResponse> getItems() {
+        return items;
+    }
+
+    public void setItems(List<ProcessorResponse> items) {
+        this.items = items;
+    }
+}

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/user/ProcessorsAPI.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/user/ProcessorsAPI.java
@@ -1,13 +1,19 @@
 package com.redhat.service.bridge.manager.api.user;
 
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -15,7 +21,19 @@ import com.redhat.service.bridge.infra.api.APIConstants;
 import com.redhat.service.bridge.manager.CustomerIdResolver;
 import com.redhat.service.bridge.manager.ProcessorService;
 import com.redhat.service.bridge.manager.api.models.requests.ProcessorRequest;
+import com.redhat.service.bridge.manager.api.models.responses.ProcessorListResponse;
+import com.redhat.service.bridge.manager.api.models.responses.ProcessorResponse;
+import com.redhat.service.bridge.manager.models.ListResult;
 import com.redhat.service.bridge.manager.models.Processor;
+
+import static com.redhat.service.bridge.infra.api.APIConstants.PAGE;
+import static com.redhat.service.bridge.infra.api.APIConstants.PAGE_DEFAULT;
+import static com.redhat.service.bridge.infra.api.APIConstants.PAGE_MIN;
+import static com.redhat.service.bridge.infra.api.APIConstants.PAGE_SIZE;
+import static com.redhat.service.bridge.infra.api.APIConstants.SIZE_DEFAULT;
+import static com.redhat.service.bridge.infra.api.APIConstants.SIZE_MAX;
+import static com.redhat.service.bridge.infra.api.APIConstants.SIZE_MIN;
+import static java.util.stream.Collectors.toList;
 
 @Path(APIConstants.USER_API_BASE_PATH)
 @Produces(MediaType.APPLICATION_JSON)
@@ -33,6 +51,23 @@ public class ProcessorsAPI {
         String customerId = customerIdResolver.resolveCustomerId();
         Processor processor = processorService.getProcessor(processorId, bridgeId, customerId);
         return Response.ok(processor.toResponse()).build();
+    }
+
+    @GET
+    @Path("{bridgeId}/processors")
+    public Response listProcessors(@NotEmpty @PathParam("bridgeId") String bridgeId, @DefaultValue(PAGE_DEFAULT) @Min(PAGE_MIN) @QueryParam(PAGE) int page,
+            @DefaultValue(SIZE_DEFAULT) @Min(SIZE_MIN) @Max(SIZE_MAX) @QueryParam(PAGE_SIZE) int pageSize) {
+
+        String customerId = customerIdResolver.resolveCustomerId();
+        ListResult<Processor> processors = processorService.getProcessors(bridgeId, customerId, page, pageSize);
+        List<ProcessorResponse> px = processors.getItems().stream().map((p) -> p.toResponse()).collect(toList());
+
+        ProcessorListResponse listResponse = new ProcessorListResponse();
+        listResponse.setItems(px);
+        listResponse.setPage(processors.getPage());
+        listResponse.setSize(processors.getSize());
+        listResponse.setTotal(processors.getTotal());
+        return Response.ok(listResponse).build();
     }
 
     @POST

--- a/manager/src/main/java/com/redhat/service/bridge/manager/dao/ProcessorDAO.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/dao/ProcessorDAO.java
@@ -3,18 +3,24 @@ package com.redhat.service.bridge.manager.dao;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 
 import com.redhat.service.bridge.infra.dto.BridgeStatus;
 import com.redhat.service.bridge.manager.models.Bridge;
+import com.redhat.service.bridge.manager.models.ListResult;
 import com.redhat.service.bridge.manager.models.Processor;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.Parameters;
 
+import static java.util.Collections.emptyList;
+
 @ApplicationScoped
 @Transactional
 public class ProcessorDAO implements PanacheRepositoryBase<Processor, String> {
+
+    private static final String IDS_PARAM = "ids";
 
     public Processor findByBridgeIdAndName(String bridgeId, String name) {
         Parameters p = Parameters.with(Processor.NAME_PARAM, name).and(Processor.BRIDGE_ID_PARAM, bridgeId);
@@ -33,5 +39,50 @@ public class ProcessorDAO implements PanacheRepositoryBase<Processor, String> {
     public List<Processor> findByStatuses(List<BridgeStatus> statuses) {
         Parameters p = Parameters.with("statuses", statuses);
         return find("#PROCESSOR.findByStatus", p).list();
+    }
+
+    private Long countProcessorsOnBridge(Parameters params) {
+        TypedQuery<Long> namedQuery = getEntityManager().createNamedQuery("PROCESSOR.countByBridgeIdAndCustomerId", Long.class);
+        addParamsToNamedQuery(params, namedQuery);
+        return namedQuery.getSingleResult();
+    }
+
+    private void addParamsToNamedQuery(Parameters params, TypedQuery<?> namedQuery) {
+        params.map().forEach((key, value) -> namedQuery.setParameter(key, value.toString()));
+    }
+
+    public ListResult<Processor> findByBridgeIdAndCustomerId(String bridgeId, String customerId, int page, int size) {
+
+        /*
+         * Unfortunately we can't rely on Panaches in-built Paging due the fetched join in our query
+         * for Processor e.g. join fetch p.bridge. Instead, we simply build a list of ids to fetch and then
+         * execute the join fetch as normal. So the workflow here is:
+         * 
+         * - Count the number of Processors on a bridge. If > 0
+         * - Select the ids of the Processors that need to be retrieved based on the page/size requirements
+         * - Select the Processors in the list of ids, performing the fetch join of the Bridge
+         */
+
+        Parameters p = Parameters.with(Bridge.CUSTOMER_ID_PARAM, customerId).and(Processor.BRIDGE_ID_PARAM, bridgeId);
+        Long processorCount = countProcessorsOnBridge(p);
+        if (processorCount == 0L) {
+            return new ListResult<>(emptyList(), page, processorCount);
+        }
+
+        int firstResult = getFirstResult(page, size);
+        TypedQuery<String> idsQuery = getEntityManager().createNamedQuery("PROCESSOR.idsByBridgeIdAndCustomerId", String.class);
+        addParamsToNamedQuery(p, idsQuery);
+        List<String> ids = idsQuery.setMaxResults(size).setFirstResult(firstResult).getResultList();
+
+        List<Processor> processors = list("#PROCESSOR.findByIds", Parameters.with(IDS_PARAM, ids));
+        return new ListResult<>(processors, page, processorCount);
+    }
+
+    private int getFirstResult(int requestedPage, int requestedPageSize) {
+        if (requestedPage <= 0) {
+            return 0;
+        }
+
+        return requestedPage * requestedPageSize;
     }
 }

--- a/manager/src/main/java/com/redhat/service/bridge/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/models/Processor.java
@@ -26,7 +26,13 @@ import com.redhat.service.bridge.manager.api.models.responses.ProcessorResponse;
         @NamedQuery(name = "PROCESSOR.findByStatus",
                 query = "from Processor p join fetch p.bridge where p.status in (:statuses) and p.bridge.status='AVAILABLE'"),
         @NamedQuery(name = "PROCESSOR.findByIdBridgeIdAndCustomerId",
-                query = "from Processor p join fetch p.bridge where p.id=:id and (p.bridge.id=:bridgeId and p.bridge.customerId=:customerId)")
+                query = "from Processor p join fetch p.bridge where p.id=:id and (p.bridge.id=:bridgeId and p.bridge.customerId=:customerId)"),
+        @NamedQuery(name = "PROCESSOR.countByBridgeIdAndCustomerId",
+                query = "select count(p.id) from Processor p where p.bridge.id=:bridgeId and p.bridge.customerId=:customerId"),
+        @NamedQuery(name = "PROCESSOR.idsByBridgeIdAndCustomerId",
+                query = "select p.id from Processor p where p.bridge.id=:bridgeId and p.bridge.customerId=:customerId order by p.submittedAt asc"),
+        @NamedQuery(name = "PROCESSOR.findByIds",
+                query = "select p from Processor p join fetch p.bridge where p.id in (:ids)")
 })
 @Entity
 public class Processor {

--- a/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
@@ -19,6 +19,7 @@ import com.redhat.service.bridge.manager.exceptions.AlreadyExistingItemException
 import com.redhat.service.bridge.manager.exceptions.BridgeLifecycleException;
 import com.redhat.service.bridge.manager.exceptions.ItemNotFoundException;
 import com.redhat.service.bridge.manager.models.Bridge;
+import com.redhat.service.bridge.manager.models.ListResult;
 import com.redhat.service.bridge.manager.models.Processor;
 import com.redhat.service.bridge.manager.utils.DatabaseManagerUtils;
 
@@ -194,5 +195,36 @@ public class ProcessorServiceTest {
         assertThat(processor, is(notNullValue()));
 
         assertThrows(ItemNotFoundException.class, () -> processorService.getProcessor("doesNotExist", b.getId(), b.getCustomerId()));
+    }
+
+    @Test
+    public void getProcessors() {
+        Bridge b = createBridge(BridgeStatus.AVAILABLE);
+        ProcessorRequest r = new ProcessorRequest("My Processor");
+
+        Processor processor = processorService.createProcessor(b.getId(), b.getCustomerId(), r);
+        assertThat(processor, is(notNullValue()));
+
+        ListResult<Processor> results = processorService.getProcessors(b.getId(), TestConstants.DEFAULT_CUSTOMER_ID, 0, 100);
+        assertThat(results.getPage(), equalTo(0L));
+        assertThat(results.getSize(), equalTo(1L));
+        assertThat(results.getTotal(), equalTo(1L));
+
+        assertThat(results.getItems().get(0).getId(), equalTo(processor.getId()));
+    }
+
+    @Test
+    public void getProcessors_noProcessorsOnBridge() {
+
+        Bridge b = createBridge(BridgeStatus.AVAILABLE);
+        ListResult<Processor> results = processorService.getProcessors(b.getId(), TestConstants.DEFAULT_CUSTOMER_ID, 0, 100);
+        assertThat(results.getPage(), equalTo(0L));
+        assertThat(results.getSize(), equalTo(0L));
+        assertThat(results.getTotal(), equalTo(0L));
+    }
+
+    @Test
+    public void getProcessors_bridgeDoesNotExist() {
+        assertThrows(ItemNotFoundException.class, () -> processorService.getProcessors("doesNotExist", TestConstants.DEFAULT_CUSTOMER_ID, 0, 100));
     }
 }

--- a/manager/src/test/java/com/redhat/service/bridge/manager/dao/ProcessorDAOTest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/dao/ProcessorDAOTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import com.redhat.service.bridge.infra.dto.BridgeStatus;
 import com.redhat.service.bridge.manager.TestConstants;
 import com.redhat.service.bridge.manager.models.Bridge;
+import com.redhat.service.bridge.manager.models.ListResult;
 import com.redhat.service.bridge.manager.models.Processor;
 import com.redhat.service.bridge.manager.utils.DatabaseManagerUtils;
 
@@ -129,5 +130,42 @@ public class ProcessorDAOTest {
 
         Processor found = processorDAO.findByIdBridgeIdAndCustomerId("doesntExist", b.getId(), b.getCustomerId());
         assertThat(found, is(nullValue()));
+    }
+
+    @Test
+    public void findByBridgeIdAndCustomerId() {
+        Bridge b = createBridge();
+        Processor p = createProcessor(b, "foo");
+        Processor p1 = createProcessor(b, "bar");
+
+        ListResult<Processor> listResult = processorDAO.findByBridgeIdAndCustomerId(b.getId(), TestConstants.DEFAULT_CUSTOMER_ID, 0, 100);
+        assertThat(listResult.getPage(), equalTo(0L));
+        assertThat(listResult.getSize(), equalTo(2L));
+        assertThat(listResult.getTotal(), equalTo(2L));
+
+        listResult.getItems().forEach((px) -> assertThat(px.getId(), in(asList(p.getId(), p1.getId()))));
+    }
+
+    @Test
+    public void findByBridgeIdAndCustomerId_noProcessors() {
+        Bridge b = createBridge();
+        ListResult<Processor> listResult = processorDAO.findByBridgeIdAndCustomerId(b.getId(), TestConstants.DEFAULT_CUSTOMER_ID, 0, 100);
+        assertThat(listResult.getPage(), equalTo(0L));
+        assertThat(listResult.getSize(), equalTo(0L));
+        assertThat(listResult.getTotal(), equalTo(0L));
+    }
+
+    @Test
+    public void findByBridgeIdAndCustomerId_pageOffset() {
+        Bridge b = createBridge();
+        Processor p = createProcessor(b, "foo");
+        Processor p1 = createProcessor(b, "bar");
+
+        ListResult<Processor> listResult = processorDAO.findByBridgeIdAndCustomerId(b.getId(), TestConstants.DEFAULT_CUSTOMER_ID, 1, 1);
+        assertThat(listResult.getPage(), equalTo(1L));
+        assertThat(listResult.getSize(), equalTo(1L));
+        assertThat(listResult.getTotal(), equalTo(2L));
+
+        assertThat(listResult.getItems().get(0).getId(), equalTo(p1.getId()));
     }
 }

--- a/manager/src/test/java/com/redhat/service/bridge/manager/utils/TestUtils.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/utils/TestUtils.java
@@ -32,6 +32,11 @@ public class TestUtils {
                 .get(APIConstants.USER_API_BASE_PATH + id);
     }
 
+    public static Response listProcessors(String bridgeId, int page, int size) {
+        return jsonRequest()
+                .get(APIConstants.USER_API_BASE_PATH + bridgeId + "/processors?size=" + size + "&page=" + page);
+    }
+
     public static Response getProcessor(String bridgeId, String processorId) {
         return jsonRequest()
                 .get(APIConstants.USER_API_BASE_PATH + bridgeId + "/processors/" + processorId);


### PR DESCRIPTION
This PR adds support for a `GET` to `/api/v1/bridges/{id}/processors` to list all of the Processors on a Bridge:

- The list of Processors is returned in ascending order of date submitted (oldest Processor first in the list)
- Pagination is supported using the `page` and `size` query params.