### PR TITLE
Skip CD job in fork repos

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -19,6 +19,7 @@ jobs:
       OUTPUT_CONTAINER_NAME: quay.io/5733d9e2be6485d52ffa08870cabdee0/event-bridge-all-in-one:${{ github.sha }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    if: github.repository == '5733d9e2be6485d52ffa08870cabdee0/sandbox'
     name: Publish JARs and Containers
     steps:
       - name: Disk space report before modification

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,4 +1,4 @@
-name: Event Bridge - CD
+name: Bridge - CD
 on:
   push:
     branches:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,4 +1,4 @@
-name: Event Bridge - CI
+name: Bridge - CI
 on: [pull_request]
 jobs:
   event-bridge-build:


### PR DESCRIPTION
Avoid to trigger a CD job every time a new commit is pushed on `main` branch of a fork