### PR TITLE
MGDOBR-73: fix ManagerSyncServiceTest.testBridgesAreDeployed random failures

### DIFF
--- a/shard/src/test/java/com/redhat/service/bridge/shard/ManagerSyncServiceTest.java
+++ b/shard/src/test/java/com/redhat/service/bridge/shard/ManagerSyncServiceTest.java
@@ -36,7 +36,7 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
         stubBridgeUpdate();
         String expectedJsonUpdateRequest = "{\"id\": \"myId-1\", \"name\": \"myName-1\", \"endpoint\": \"myEndpoint\", \"customerId\": \"myCustomerId\", \"status\": \"PROVISIONING\"}";
 
-        CountDownLatch latch = new CountDownLatch(2); // Two updates to the manager are expected
+        CountDownLatch latch = new CountDownLatch(4); // Four updates to the manager are expected (2 PROVISIONING + 2 AVAILABLE)
         addBridgeUpdateRequestListener(latch);
 
         managerSyncService.fetchAndProcessBridgesToDeployOrDelete().await().atMost(Duration.ofSeconds(5));
@@ -90,9 +90,10 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
         ProcessorDTO processor = createProcessor(bridge, BridgeStatus.REQUESTED);
 
         stubProcessorsToDeployOrDelete(Collections.singletonList(processor));
+        stubProcessorUpdate();
+
         CountDownLatch latch = new CountDownLatch(1);
         addProcessorUpdateRequestListener(latch);
-
         managerSyncService.fetchAndProcessProcessorsToDeployOrDelete().await().atMost(Duration.ofSeconds(5));
         assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 


### PR DESCRIPTION
[MGDOBR-73](https://issues.redhat.com/browse/MGDOBR-73) 

The `ManagerSyncServiceTest.testBridgesAreDeployed` is creating **two** Bridges instances. For each Bridge instance that is deployed, the shard will make **two** PUT requests to the `manager`: one to notify that the resource is in `PROVISIONING` state, and another one for that the resource is `AVAILABLE`. 

So **four** PUT requests are actually made by the shard, but the test was only waiting for **two** PUT requests to be sent to the server mock. The flow was like the following: 

1) two PUT requests are received (for example: bridge `myName-2` is provisioning and bridge `myName-2` is available). 
2) the test verifies that 
```java
        verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
                .withRequestBody(equalToJson(expectedJsonUpdateRequest, true, true))
                .withHeader("Content-Type", equalTo("application/json")));
```
for bridge `myName-1` and fails
3) the wiremock server receives the two PUT requests from the shard about the bridge `myName-1`
4) the wiremock library builds the `new VerificationException` looking for near misses and finds the new requests

This is why the error messages are misleading. 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested and uses org.assertj.core.api.Assertions for Assertions
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket