### PR TITLE
MGDOBR-54: enable support for non-cloud events

### DIFF
--- a/executor/src/test/java/com/redhat/service/bridge/executor/TestUtils.java
+++ b/executor/src/test/java/com/redhat/service/bridge/executor/TestUtils.java
@@ -1,0 +1,20 @@
+package com.redhat.service.bridge.executor;
+
+import java.net.URI;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.service.bridge.infra.BridgeCloudEventExtension;
+import com.redhat.service.bridge.infra.utils.CloudEventUtils;
+
+import io.cloudevents.CloudEvent;
+
+public class TestUtils {
+
+    public static final String BRIDGE_ID = "myBridge";
+
+    public static CloudEvent buildTestCloudEvent() throws JsonProcessingException {
+        String jsonString = "{\"k1\":\"v1\",\"k2\":\"v2\"}";
+        return CloudEventUtils.build("myId", URI.create("mySource"), "subject", new ObjectMapper().readTree(jsonString), new BridgeCloudEventExtension(BRIDGE_ID));
+    }
+}

--- a/ingress/src/main/java/com/redhat/service/bridge/ingress/IngressService.java
+++ b/ingress/src/main/java/com/redhat/service/bridge/ingress/IngressService.java
@@ -1,10 +1,10 @@
 package com.redhat.service.bridge.ingress;
 
-import io.cloudevents.CloudEvent;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public interface IngressService {
 
-    void processEvent(String id, CloudEvent event);
+    void processEvent(String id, JsonNode event);
 
     // TODO: remove after we move to k8s
     String deploy(String id);

--- a/ingress/src/main/java/com/redhat/service/bridge/ingress/IngressServiceImpl.java
+++ b/ingress/src/main/java/com/redhat/service/bridge/ingress/IngressServiceImpl.java
@@ -6,10 +6,9 @@ import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.service.bridge.ingress.api.exceptions.IngressException;
 import com.redhat.service.bridge.ingress.producer.KafkaEventPublisher;
-
-import io.cloudevents.CloudEvent;
 
 @ApplicationScoped
 public class IngressServiceImpl implements IngressService {
@@ -20,7 +19,7 @@ public class IngressServiceImpl implements IngressService {
     KafkaEventPublisher kafkaEventPublisher;
 
     @Override
-    public void processEvent(String id, CloudEvent event) {
+    public void processEvent(String id, JsonNode event) {
         //TODO: remove after we move to k8s
         if (!deployments.contains(id)) {
             throw new IngressException("Ingress with name " + id + " is not deployed.");

--- a/ingress/src/main/java/com/redhat/service/bridge/ingress/api/IngressAPI.java
+++ b/ingress/src/main/java/com/redhat/service/bridge/ingress/api/IngressAPI.java
@@ -13,9 +13,8 @@ import javax.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.service.bridge.ingress.IngressService;
-
-import io.cloudevents.CloudEvent;
 
 //TODO: when we move to k8s, revisit the endpoint name
 @Path("/ingress")
@@ -30,7 +29,7 @@ public class IngressAPI {
     @Path("/events/{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response publishEvent(@PathParam("name") @NotNull String name, @NotNull CloudEvent event) {
+    public Response publishEvent(@PathParam("name") @NotNull String name, @NotNull JsonNode event) {
         LOGGER.debug("[ingress] new event has been uploaded to endpoint /ingress/events/{}", name);
         ingressService.processEvent(name, event);
         return Response.ok().build();

--- a/ingress/src/test/java/com/redhat/service/bridge/ingress/IngressServiceTest.java
+++ b/ingress/src/test/java/com/redhat/service/bridge/ingress/IngressServiceTest.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.service.bridge.ingress.api.exceptions.IngressException;
 import com.redhat.service.bridge.ingress.producer.KafkaEventPublisher;
 
-import io.cloudevents.CloudEvent;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
@@ -33,23 +33,23 @@ public class IngressServiceTest {
     @BeforeAll
     public static void setup() {
         KafkaEventPublisher mock = Mockito.mock(KafkaEventPublisher.class);
-        Mockito.doNothing().when(mock).sendEvent(any(String.class), any(CloudEvent.class));
+        Mockito.doNothing().when(mock).sendEvent(any(String.class), any(JsonNode.class));
         QuarkusMock.installMockForType(mock, KafkaEventPublisher.class);
     }
 
     @Test
     public void testSendEvent() throws JsonProcessingException {
         ingressService.deploy("topicName"); // TODO: remove after we move to k8s
-        ingressService.processEvent("topicName", TestUtils.buildTestCloudEvent());
+        ingressService.processEvent("topicName", TestUtils.buildTestCloudEventAsJsonNode());
 
-        verify(kafkaEventPublisher, times(1)).sendEvent(eq("topicName"), any(CloudEvent.class));
+        verify(kafkaEventPublisher, times(1)).sendEvent(eq("topicName"), any(JsonNode.class));
         ingressService.undeploy("topicName");
     }
 
     @Test
     // TODO: remove after we move to k8s
     public void testSendEventToUndeployedInstance() throws JsonProcessingException {
-        assertThatExceptionOfType(IngressException.class).isThrownBy(() -> ingressService.processEvent("topicName", TestUtils.buildTestCloudEvent()));
-        verify(kafkaEventPublisher, times(0)).sendEvent(eq("topicName"), any(CloudEvent.class));
+        assertThatExceptionOfType(IngressException.class).isThrownBy(() -> ingressService.processEvent("topicName", TestUtils.buildTestCloudEventAsJsonNode()));
+        verify(kafkaEventPublisher, times(0)).sendEvent(eq("topicName"), any(JsonNode.class));
     }
 }

--- a/ingress/src/test/java/com/redhat/service/bridge/ingress/TestUtils.java
+++ b/ingress/src/test/java/com/redhat/service/bridge/ingress/TestUtils.java
@@ -3,24 +3,21 @@ package com.redhat.service.bridge.ingress;
 import java.net.URI;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.service.bridge.infra.utils.CloudEventUtils;
 
 import io.cloudevents.CloudEvent;
-import io.cloudevents.core.builder.CloudEventBuilder;
 
 public class TestUtils {
 
     public static CloudEvent buildTestCloudEvent() throws JsonProcessingException {
-        return builderForTestCloudEvent().build();
-    }
-
-    public static CloudEvent buildTestCloudEventWithReservedAttributes() throws JsonProcessingException {
-        return builderForTestCloudEvent().withExtension("ebbridgeid", "foo").build();
-    }
-
-    private static CloudEventBuilder builderForTestCloudEvent() throws JsonProcessingException {
         String jsonString = "{\"k1\":\"v1\",\"k2\":\"v2\"}";
-        return CloudEventUtils.builderFor("myId", "myTopic", URI.create("mySource"), "subject", new ObjectMapper().readTree(jsonString));
+        return CloudEventUtils.build("myId", URI.create("mySource"), "subject", new ObjectMapper().readTree(jsonString));
+    }
+
+    public static JsonNode buildTestCloudEventAsJsonNode() throws JsonProcessingException {
+        CloudEvent cloudEvent = buildTestCloudEvent();
+        return CloudEventUtils.getMapper().readTree(CloudEventUtils.encode(cloudEvent));
     }
 }

--- a/ingress/src/test/java/com/redhat/service/bridge/ingress/producer/KafkaEventPublisherTest.java
+++ b/ingress/src/test/java/com/redhat/service/bridge/ingress/producer/KafkaEventPublisherTest.java
@@ -9,14 +9,12 @@ import org.junit.jupiter.api.Test;
 import com.redhat.service.bridge.infra.BridgeCloudEventExtension;
 import com.redhat.service.bridge.infra.utils.CloudEventUtils;
 import com.redhat.service.bridge.ingress.TestUtils;
-import com.redhat.service.bridge.ingress.api.exceptions.BadRequestException;
 
 import io.cloudevents.CloudEvent;
 import io.cloudevents.core.provider.ExtensionProvider;
 import io.smallrye.mutiny.helpers.test.AssertSubscriber;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class KafkaEventPublisherTest {
 
@@ -33,7 +31,7 @@ public class KafkaEventPublisherTest {
         KafkaEventPublisher producer = new KafkaEventPublisher();
         producer.getEventPublisher().subscribe(subscriber);
 
-        producer.sendEvent(bridgeId, TestUtils.buildTestCloudEvent());
+        producer.sendEvent(bridgeId, TestUtils.buildTestCloudEventAsJsonNode());
         List<String> sentEvents = subscriber.getItems();
         assertThat(sentEvents.size()).isEqualTo(1);
 
@@ -41,20 +39,5 @@ public class KafkaEventPublisherTest {
         BridgeCloudEventExtension bridgeCloudEventExtension = ExtensionProvider.getInstance().parseExtension(BridgeCloudEventExtension.class, cloudEvent);
 
         assertThat(bridgeCloudEventExtension.getBridgeId()).isEqualTo(bridgeId);
-    }
-
-    @Test
-    void testEventIsNotProducedIfInputContainsReservedAttributes() throws IOException {
-        String bridgeId = "myBridge";
-        AssertSubscriber<String> subscriber = AssertSubscriber.create(1);
-
-        KafkaEventPublisher producer = new KafkaEventPublisher();
-        producer.getEventPublisher().subscribe(subscriber);
-
-        CloudEvent inputEvent = TestUtils.buildTestCloudEventWithReservedAttributes();
-        assertThatExceptionOfType(BadRequestException.class).isThrownBy(() -> producer.sendEvent(bridgeId, inputEvent));
-
-        List<String> sentEvents = subscriber.getItems();
-        assertThat(sentEvents.size()).isZero();
     }
 }

--- a/runner/src/test/java/com/redhat/service/bridge/runner/it/End2EndTestIT.java
+++ b/runner/src/test/java/com/redhat/service/bridge/runner/it/End2EndTestIT.java
@@ -274,7 +274,7 @@ public class End2EndTestIT {
     private String buildTestCloudEvent() throws JsonProcessingException {
         String jsonString = "{\"k1\":\"v1\",\"k2\":\"v2\"}";
         return CloudEventUtils.encode(
-                CloudEventUtils.build("myId", "myTopic", URI.create("mySource"), "subject", new ObjectMapper().readTree(jsonString)));
+                CloudEventUtils.build("myId", URI.create("mySource"), "subject", new ObjectMapper().readTree(jsonString)));
     }
 
     private RequestSpecification jsonRequestWithAuth() {


### PR DESCRIPTION
[MGDOBR-54](https://issues.redhat.com/browse/MGDOBR-54) 

The changes from a logical perspective is the following: 
![Screenshot from 2021-10-08 11-11-11](https://user-images.githubusercontent.com/18282531/136530416-3a2399a8-01b3-4a87-abab-babf09cdb04f.png)

In other words: 
1) the only requirement for the user is to send JSON data. 
2) The ingress application wraps the user's data with a cloud event (the user's data is put in the `data`). 
3) **The validation of the reserved OB extensions is not needed anymore**: the user can send any JSON payload. 
4) The cloud event envelope is sent to kafka
5) The executor service reads the cloud event envelope and extract the metadata it needs (for example the `ebbridgeid` extension)
6) The executor service extracts the user's JSON data from the `data`, and pass it to the `Executor` so to move forward with the processing (filtering/transformation/action).

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested and uses org.assertj.core.api.Assertions for Assertions
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket