### PR TITLE
MGDOBR-80: filter duplicate Processors

### DIFF
--- a/manager/src/main/java/com/redhat/service/bridge/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/models/Processor.java
@@ -27,6 +27,7 @@ import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.filters.BaseFilter;
 import com.redhat.service.bridge.manager.api.models.responses.ProcessorResponse;
 
+// The join fetch on the filters will produce duplicates that must be removed from the results (see https://developer.jboss.org/docs/DOC-15782#jive_content_id_Hibernate_does_not_return_distinct_results_for_a_query_with_outer_join_fetching_enabled_for_a_collection_even_if_I_use_the_distinct_keyword)
 @NamedQueries({
         @NamedQuery(name = "PROCESSOR.findByBridgeIdAndName",
                 query = "from Processor p where p.name=:name and p.bridge.id=:bridgeId"),


### PR DESCRIPTION
[MGDOBR-80](https://issues.redhat.com/browse/MGDOBR-80) 

We are affected by the following bug: if a processor contains multiple filters, the queries that use a `join fetch` on the filters will produce duplicate processors. This behavior is expected and must be fixed using [this](https://developer.jboss.org/docs/DOC-15782#jive_content_id_Hibernate_does_not_return_distinct_results_for_a_query_with_outer_join_fetching_enabled_for_a_collection_even_if_I_use_the_distinct_keyword).

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested and uses org.assertj.core.api.Assertions for Assertions
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket