### PR TITLE
MGDOBR-85: shard tests use dynamic port for wiremock server

### DIFF
--- a/shard/src/test/java/com/redhat/service/bridge/shard/AbstractShardWireMockTest.java
+++ b/shard/src/test/java/com/redhat/service/bridge/shard/AbstractShardWireMockTest.java
@@ -83,28 +83,28 @@ public abstract class AbstractShardWireMockTest {
     }
 
     protected void stubProcessorsToDeployOrDelete(List<ProcessorDTO> processorDTOS) throws JsonProcessingException {
-        stubFor(get(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
+        wireMockServer.stubFor(get(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withBody(objectMapper.writeValueAsString(processorDTOS))));
     }
 
     protected void stubBridgesToDeployOrDelete(List<BridgeDTO> bridgeDTOs) throws JsonProcessingException {
-        stubFor(get(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
+        wireMockServer.stubFor(get(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withBody(objectMapper.writeValueAsString(bridgeDTOs))));
     }
 
     protected void stubProcessorUpdate() {
-        stubFor(put(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
+        wireMockServer.stubFor(put(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withStatus(200)));
     }
 
     protected void stubBridgeUpdate() {
-        stubFor(put(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
+        wireMockServer.stubFor(put(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
                         .withStatus(200)));

--- a/shard/src/test/java/com/redhat/service/bridge/shard/ManagerMockResource.java
+++ b/shard/src/test/java/com/redhat/service/bridge/shard/ManagerMockResource.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
@@ -13,7 +14,7 @@ public class ManagerMockResource implements QuarkusTestResourceLifecycleManager 
 
     @Override
     public Map<String, String> start() {
-        wireMockServer = new WireMockServer();
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
         wireMockServer.start();
 
         return Collections.singletonMap("event-bridge.manager.url", wireMockServer.baseUrl());

--- a/shard/src/test/java/com/redhat/service/bridge/shard/ManagerSyncServiceTest.java
+++ b/shard/src/test/java/com/redhat/service/bridge/shard/ManagerSyncServiceTest.java
@@ -42,7 +42,7 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
         managerSyncService.fetchAndProcessBridgesToDeployOrDelete().await().atMost(Duration.ofSeconds(5));
 
         assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
-        verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
                 .withRequestBody(equalToJson(expectedJsonUpdateRequest, true, true))
                 .withHeader("Content-Type", equalTo("application/json")));
     }
@@ -62,7 +62,7 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
         managerSyncService.fetchAndProcessBridgesToDeployOrDelete().await().atMost(Duration.ofSeconds(5));
 
         assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
-        verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
                 .withRequestBody(equalToJson(expectedJsonUpdateRequest, true, true))
                 .withHeader("Content-Type", equalTo("application/json")));
     }
@@ -79,7 +79,7 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
         managerSyncService.notifyBridgeStatusChange(dto).await().atMost(Duration.ofSeconds(5));
 
         assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
-        verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
                 .withRequestBody(equalToJson(expectedJsonUpdate, true, true))
                 .withHeader("Content-Type", equalTo("application/json")));
     }
@@ -99,7 +99,7 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
 
         processor.setStatus(BridgeStatus.PROVISIONING);
 
-        verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(processor), true, true))
                 .withHeader("Content-Type", equalTo("application/json")));
     }
@@ -116,7 +116,7 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
         managerSyncService.notifyProcessorStatusChange(processor).await().atMost(Duration.ofSeconds(5));
 
         assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
-        verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(processor), true, true))
                 .withHeader("Content-Type", equalTo("application/json")));
     }

--- a/shard/src/test/java/com/redhat/service/bridge/shard/controllers/ProcessorControllerTest.java
+++ b/shard/src/test/java/com/redhat/service/bridge/shard/controllers/ProcessorControllerTest.java
@@ -9,7 +9,6 @@ import javax.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.redhat.service.bridge.infra.api.APIConstants;
 import com.redhat.service.bridge.infra.k8s.Action;
 import com.redhat.service.bridge.infra.k8s.K8SBridgeConstants;
@@ -57,7 +56,7 @@ public class ProcessorControllerTest extends AbstractShardWireMockTest {
 
         processor.setStatus(BridgeStatus.AVAILABLE);
 
-        WireMock.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(processor), true, true))
                 .withHeader("Content-Type", equalTo("application/json")));
 
@@ -89,7 +88,7 @@ public class ProcessorControllerTest extends AbstractShardWireMockTest {
 
         processor.setStatus(BridgeStatus.FAILED);
 
-        WireMock.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH + "processors"))
                 .withRequestBody(equalToJson(objectMapper.writeValueAsString(processor), true, true))
                 .withHeader("Content-Type", equalTo("application/json")));
 


### PR DESCRIPTION
[MGDOBR-85](https://issues.redhat.com/browse/MGDOBR-85) 

This PR aims to configure wiremock to use a dynamic port for tests (shard). 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested and uses org.assertj.core.api.Assertions for Assertions
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket