### PR TITLE
MGDOBR-113 Shard operator fails to start due to Kafka messaging depe…

### DIFF
--- a/shard-operator/pom.xml
+++ b/shard-operator/pom.xml
@@ -47,10 +47,6 @@
       <groupId>com.redhat.service.bridge</groupId>
       <artifactId>infra</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.redhat.service.bridge</groupId>
-      <artifactId>actions</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -79,6 +75,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.redhat.service.bridge</groupId>
+      <artifactId>actions</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
…ndency

Signed-off-by: Karel Suta <ksuta@redhat.com>

[MGDOBR-113](https://issues.redhat.com/browse/MGDOBR-113) 

Actions artifact brings Kafka transitive dependency, causing operator to fail on startup due to missing Kafka connection.

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
