### PR TITLE
[MGDOBR-143] Adding IN filter

### DIFF
--- a/FILTERS.md
+++ b/FILTERS.md
@@ -107,3 +107,35 @@ Then an event like
 
 Would evaluate the Filter to `true`.
 
+### ValuesIn
+
+The `ValuesIn` evaluates to `true` if the **key** value is equal to any of the values specified in the filter **values**.
+
+Assuming that the Filter is the following
+
+```json
+
+{
+  "filters": [
+    {
+      "type": "ValuesIn", 
+      "key": "data.any",
+      "value": ["Jac", 2]
+    }
+  ]
+}
+```
+
+Then an event like
+```json
+{
+  ...
+  "data": {
+    "any": 2
+  }
+}
+```
+
+Would evaluate the Filter to `true`.
+
+

--- a/executor/src/test/java/com/redhat/service/bridge/executor/filters/FilterEvaluatorFEELTest.java
+++ b/executor/src/test/java/com/redhat/service/bridge/executor/filters/FilterEvaluatorFEELTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import com.redhat.service.bridge.infra.models.filters.StringBeginsWith;
 import com.redhat.service.bridge.infra.models.filters.StringContains;
 import com.redhat.service.bridge.infra.models.filters.StringEquals;
+import com.redhat.service.bridge.infra.models.filters.ValuesIn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +47,17 @@ public class FilterEvaluatorFEELTest {
 
         assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", "myService"))).isTrue();
         assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", "myTest"))).isTrue();
+        assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", "notMyApplication"))).isFalse();
+    }
+
+    @Test
+    public void testInFilter() {
+        FilterEvaluator evaluator = TEMPLATE_FACTORY_FEEL.build(Collections.singleton(new ValuesIn("source", "[\"Service\", \"Testing\", 2]")));
+
+        assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", "Service"))).isTrue();
+        assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", "Testing"))).isTrue();
+        assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", 2))).isTrue();
+        assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", "2"))).isFalse();
         assertThat(evaluator.evaluateFilters(Collections.singletonMap("source", "notMyApplication"))).isFalse();
     }
 

--- a/executor/src/test/java/com/redhat/service/bridge/executor/filters/FilterEvaluatorFactoryFEELTest.java
+++ b/executor/src/test/java/com/redhat/service/bridge/executor/filters/FilterEvaluatorFactoryFEELTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import com.redhat.service.bridge.infra.models.filters.StringBeginsWith;
 import com.redhat.service.bridge.infra.models.filters.StringContains;
 import com.redhat.service.bridge.infra.models.filters.StringEquals;
+import com.redhat.service.bridge.infra.models.filters.ValuesIn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,6 +39,13 @@ public class FilterEvaluatorFactoryFEELTest {
 
         String expectedMulti = "if (starts with (data.name, \"jacopo\")) or (starts with (data.name, \"rota\")) then \"OK\" else \"NOT_OK\"";
         String templateMulti = TEMPLATE_FACTORY_FEEL.getTemplateByFilterType(new StringBeginsWith("data.name", "[\"jacopo\", \"rota\"]"));
+        assertThat(templateMulti).isEqualTo(expectedMulti);
+    }
+
+    @Test
+    public void valuesInWithTemplate() {
+        String expectedMulti = "if data.name = \"jacopo\" or data.name = \"rota\" or data.name = 2 then \"OK\" else \"NOT_OK\"";
+        String templateMulti = TEMPLATE_FACTORY_FEEL.getTemplateByFilterType(new ValuesIn("data.name", "[\"jacopo\", \"rota\", 2]"));
         assertThat(templateMulti).isEqualTo(expectedMulti);
     }
 }

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/BaseFilter.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/BaseFilter.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -14,10 +13,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
         @JsonSubTypes.Type(value = StringBeginsWith.class, name = StringBeginsWith.FILTER_TYPE_NAME),
         @JsonSubTypes.Type(value = StringContains.class, name = StringContains.FILTER_TYPE_NAME),
         @JsonSubTypes.Type(value = StringEquals.class, name = StringEquals.FILTER_TYPE_NAME),
+        @JsonSubTypes.Type(value = ValuesIn.class, name = ValuesIn.FILTER_TYPE_NAME)
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class BaseFilter {
-    protected static final ObjectMapper MAPPER = new ObjectMapper();
+public abstract class BaseFilter<T> {
 
     public static final String FILTER_TYPE_FIELD = "type";
 
@@ -27,15 +26,12 @@ public abstract class BaseFilter {
     @JsonProperty("key")
     protected String key;
 
-    public BaseFilter() {
+    protected BaseFilter(String type) {
+        this.type = type;
     }
 
-    public BaseFilter(String key, String value) {
-        this.key = key;
-        setValueFromString(value);
-    }
-
-    public void setKey(String key) {
+    protected BaseFilter(String type, String key) {
+        this(type);
         this.key = key;
     }
 
@@ -43,20 +39,10 @@ public abstract class BaseFilter {
         return key;
     }
 
-    public void setType(String type) {
-        this.type = type;
-    }
-
     public String getType() {
         return type;
     }
 
     @JsonIgnore
-    public abstract String getValueAsString();
-
-    @JsonIgnore
-    public abstract Object getValue();
-
-    @JsonIgnore
-    protected abstract void setValueFromString(String value);
+    public abstract T getValue();
 }

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/FilterFactory.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/FilterFactory.java
@@ -9,6 +9,8 @@ public class FilterFactory {
                 return new StringContains(key, value);
             case StringEquals.FILTER_TYPE_NAME:
                 return new StringEquals(key, value);
+            case ValuesIn.FILTER_TYPE_NAME:
+                return new ValuesIn(key, value);
             default:
                 throw new IllegalArgumentException("Type " + type + " is not valid");
         }

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/ObjectMapperFactory.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/ObjectMapperFactory.java
@@ -1,0 +1,15 @@
+package com.redhat.service.bridge.infra.models.filters;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ObjectMapperFactory {
+
+    private static ObjectMapper mapper = new ObjectMapper();
+
+    public static ObjectMapper get() {
+        return mapper;
+    }
+
+    private ObjectMapperFactory() {
+    }
+}

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/StringBeginsWith.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/StringBeginsWith.java
@@ -6,47 +6,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 
-public class StringBeginsWith extends BaseFilter {
+public class StringBeginsWith extends BaseFilter<List<String>> {
     public static final String FILTER_TYPE_NAME = "StringBeginsWith";
-
-    @JsonProperty("type")
-    private String type = FILTER_TYPE_NAME;
 
     @JsonProperty("values")
     private List<String> values;
 
     public StringBeginsWith() {
+        super(FILTER_TYPE_NAME);
     }
 
     public StringBeginsWith(String key, String values) {
-        super(key, values);
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    @Override
-    public String getValueAsString() {
+        super(FILTER_TYPE_NAME, key);
         try {
-            return MAPPER.writeValueAsString(values);
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Could not serialize the values for StringBeginsWith filter.");
-        }
-    }
-
-    @Override
-    public Object getValue() {
-        return values;
-    }
-
-    @Override
-    public void setValueFromString(String value) {
-        try {
-            this.values = MAPPER.readValue(value, new TypeReference<List<String>>() {
+            this.values = ObjectMapperFactory.get().readValue(values, new TypeReference<List<String>>() {
             });
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("The value is not a list of strings.");
         }
     }
+
+    @Override
+    public List<String> getValue() {
+        return values;
+    }
+
 }

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/StringContains.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/StringContains.java
@@ -6,48 +6,30 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 
-public class StringContains extends BaseFilter {
+public class StringContains extends BaseFilter<List<String>> {
 
     public static final String FILTER_TYPE_NAME = "StringContains";
-
-    @JsonProperty("type")
-    private String type = FILTER_TYPE_NAME;
-
-    public String getType() {
-        return type;
-    }
 
     @JsonProperty("values")
     private List<String> values;
 
     public StringContains() {
+        super(FILTER_TYPE_NAME);
     }
 
     public StringContains(String key, String value) {
-        super(key, value);
-    }
-
-    @Override
-    public String getValueAsString() {
+        super(FILTER_TYPE_NAME, key);
         try {
-            return MAPPER.writeValueAsString(values);
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Could not serialize the values for StringContains filter.");
-        }
-    }
-
-    @Override
-    public Object getValue() {
-        return values;
-    }
-
-    @Override
-    public void setValueFromString(String value) {
-        try {
-            this.values = MAPPER.readValue(value, new TypeReference<List<String>>() {
+            this.values = ObjectMapperFactory.get().readValue(value, new TypeReference<List<String>>() {
             });
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("The value is not a list of strings.");
         }
+
+    }
+
+    @Override
+    public List<String> getValue() {
+        return values;
     }
 }

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/StringEquals.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/StringEquals.java
@@ -2,38 +2,23 @@ package com.redhat.service.bridge.infra.models.filters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class StringEquals extends BaseFilter {
+public class StringEquals extends BaseFilter<String> {
     public static final String FILTER_TYPE_NAME = "StringEquals";
-
-    @JsonProperty("type")
-    private String type = FILTER_TYPE_NAME;
-
-    public String getType() {
-        return type;
-    }
 
     @JsonProperty("value")
     private String value;
 
     public StringEquals() {
+        super(FILTER_TYPE_NAME);
     }
 
     public StringEquals(String key, String value) {
-        super(key, value);
-    }
-
-    @Override
-    public String getValueAsString() {
-        return value;
-    }
-
-    @Override
-    public Object getValue() {
-        return value;
-    }
-
-    @Override
-    public void setValueFromString(String value) {
+        super(FILTER_TYPE_NAME, key);
         this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
     }
 }

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/ValuesIn.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/filters/ValuesIn.java
@@ -1,0 +1,33 @@
+package com.redhat.service.bridge.infra.models.filters;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class ValuesIn extends BaseFilter<List<Object>> {
+    public static final String FILTER_TYPE_NAME = "ValuesIn";
+
+    @JsonProperty("values")
+    private List<Object> values;
+
+    public ValuesIn() {
+        super(FILTER_TYPE_NAME);
+    }
+
+    @SuppressWarnings("unchecked")
+    public ValuesIn(String key, String values) {
+        super(FILTER_TYPE_NAME, key);
+        try {
+            this.values = ObjectMapperFactory.get().readValue(values, List.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("The value is not a list");
+        }
+    }
+
+    @Override
+    public List<Object> getValue() {
+        return values;
+    }
+
+}

--- a/infra/src/test/java/com/redhat/service/bridge/infra/models/filters/FilterFactoryTest.java
+++ b/infra/src/test/java/com/redhat/service/bridge/infra/models/filters/FilterFactoryTest.java
@@ -1,5 +1,6 @@
 package com.redhat.service.bridge.infra.models.filters;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,6 @@ public class FilterFactoryTest {
         assertThat(stringContainsFilter.getKey()).isEqualTo("key");
         assertThat(((List<String>) stringContainsFilter.getValue()).size()).isEqualTo(1);
         assertThat(((List<String>) stringContainsFilter.getValue()).get(0)).isEqualTo("test");
-        assertThat(stringContainsFilter.getValueAsString()).isEqualTo("[\"test\"]");
     }
 
     @Test
@@ -30,7 +30,6 @@ public class FilterFactoryTest {
         assertThat(stringBeginsFilter.getKey()).isEqualTo("key");
         assertThat(((List<String>) stringBeginsFilter.getValue()).size()).isEqualTo(1);
         assertThat(((List<String>) stringBeginsFilter.getValue()).get(0)).isEqualTo("test");
-        assertThat(stringBeginsFilter.getValueAsString()).isEqualTo("[\"test\"]");
     }
 
     @Test
@@ -39,7 +38,14 @@ public class FilterFactoryTest {
         assertThat(stringEqualsFilter).isInstanceOf(StringEquals.class);
         assertThat(stringEqualsFilter.getKey()).isEqualTo("key");
         assertThat(stringEqualsFilter.getValue()).isEqualTo("test");
-        assertThat(stringEqualsFilter.getValueAsString()).isEqualTo("test");
+    }
+
+    @Test
+    public void testValuesInFilterFactory() {
+        BaseFilter stringEqualsFilter = FilterFactory.buildFilter(ValuesIn.FILTER_TYPE_NAME, "key", "[\"test\",2]");
+        assertThat(stringEqualsFilter).isInstanceOf(ValuesIn.class);
+        assertThat(stringEqualsFilter.getKey()).isEqualTo("key");
+        assertThat(stringEqualsFilter.getValue()).isEqualTo(Arrays.asList("test", 2));
     }
 
     @Test


### PR DESCRIPTION
[https://issues.redhat.com/browse/MGDOBR-143) 
Besides adding ValuesIn class, I did some refactor, trying to keep what I though was the original idea behind BaseFilter hierarchy.  
Some rationale that might or not be shared below ;):
-  getValuesAsString method is not really needed and, if was so, I think building the string represantion belongs to filter generation, not to BaseFilter hierarchy. 
- A generic was added to BaseFilter (which requires casting to subclass, but this was already assumed by checking the class type before) so now there is a cast class but not a value cast (which I believe is part of the logic inherent to BaseFilter hierarchy, to hold the proper value data type in the child filter)   
- ValuesIn (I name it following the type-operator convention of other BaseFilter classes), accepts a list of objects.
- ObjectMapper instance was moved to a static class. This instance is still used for builidng the internal object representation from the value string passed in the constructor (Im not sure we should pass a string, but I agree is useful for testing, so I kept that) 

