### PR TITLE
[MGDOBR-156] BridgeIngress builder refactoring

### DIFF
--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/BridgeIngress.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/BridgeIngress.java
@@ -1,5 +1,8 @@
 package com.redhat.service.bridge.shard.operator.resources;
 
+import java.util.Objects;
+
+import com.google.common.base.Strings;
 import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
 
@@ -13,7 +16,7 @@ import io.fabric8.kubernetes.model.annotation.ShortNames;
 import io.fabric8.kubernetes.model.annotation.Version;
 
 /**
- * Placeholder for the OpenBridge Ingress Custom Resource. To be defined on <a href="MGDOBR-91">https://issues.redhat.com/browse/MGDOBR-91</a>
+ * OpenBridge Ingress Custom Resource
  */
 @Group("com.redhat.service.bridge")
 @Version("v1alpha1")
@@ -24,27 +27,27 @@ public class BridgeIngress extends CustomResource<BridgeIngressSpec, BridgeIngre
 
     private static final String OB_RESOURCE_NAME_PREFIX = "ob-";
 
+    // ideally this class should have a private default constructor. Unfortunately, it's a CR which is created via reflection by fabric8.
+
+    /**
+     * Standard way of creating a new {@link BridgeIngress}.
+     * This class has a public constructor for integration with Kubernetes libraries only.
+     * Please don't use the public constructor to create references of this CR.
+     *
+     * @return a Builder to help client code to create new instances of the CR.
+     */
+    public static Builder fromBuilder() {
+        return new Builder();
+    }
+
     public static BridgeIngress fromDTO(BridgeDTO bridgeDTO, String namespace, String ingressImage) {
-        ObjectMeta meta = new ObjectMetaBuilder()
-                .withName(buildResourceName(bridgeDTO.getId()))
+        return new Builder()
                 .withNamespace(namespace)
-                .withLabels(new LabelsBuilder()
-                        .withCustomerId(bridgeDTO.getCustomerId())
-                        .withComponent(COMPONENT_NAME)
-                        .buildWithDefaults())
+                .withBridgeName(bridgeDTO.getName())
+                .withCustomerId(bridgeDTO.getCustomerId())
+                .withBridgeId(bridgeDTO.getId())
+                .withImageName(ingressImage)
                 .build();
-
-        BridgeIngressSpec bridgeIngressSpec = new BridgeIngressSpec();
-        bridgeIngressSpec.setImage(ingressImage);
-        bridgeIngressSpec.setBridgeName(bridgeDTO.getName());
-        bridgeIngressSpec.setCustomerId(bridgeDTO.getCustomerId());
-        bridgeIngressSpec.setId(bridgeDTO.getId()); // metadata.name is sanitized, could not be used.
-
-        BridgeIngress bridgeIngress = new BridgeIngress();
-        bridgeIngress.setSpec(bridgeIngressSpec);
-        bridgeIngress.setMetadata(meta);
-
-        return bridgeIngress;
     }
 
     public BridgeDTO toDTO() {
@@ -56,7 +59,77 @@ public class BridgeIngress extends CustomResource<BridgeIngressSpec, BridgeIngre
         return bridgeDTO;
     }
 
-    public static String buildResourceName(String id) {
+    public static String resolveResourceName(String id) {
         return OB_RESOURCE_NAME_PREFIX + KubernetesResourceUtil.sanitizeName(id);
+    }
+
+    public static final class Builder {
+
+        private String bridgeId;
+        private String namespace;
+        private String bridgeName;
+        private String customerId;
+        private String imageName;
+
+        private Builder() {
+
+        }
+
+        public Builder withBridgeName(final String bridgeName) {
+            this.bridgeName = bridgeName;
+            return this;
+        }
+
+        public Builder withNamespace(final String namespace) {
+            this.namespace = namespace;
+            return this;
+        }
+
+        public Builder withBridgeId(final String bridgeId) {
+            this.bridgeId = bridgeId;
+            return this;
+        }
+
+        public Builder withCustomerId(final String customerId) {
+            this.customerId = customerId;
+            return this;
+        }
+
+        public Builder withImageName(final String imageName) {
+            this.imageName = imageName;
+            return this;
+        }
+
+        public BridgeIngress build() {
+            this.validate();
+            ObjectMeta meta = new ObjectMetaBuilder()
+                    .withName(resolveResourceName(this.bridgeId))
+                    .withNamespace(namespace)
+                    .withLabels(new LabelsBuilder()
+                            .withCustomerId(customerId)
+                            .withComponent(COMPONENT_NAME)
+                            .buildWithDefaults())
+                    .build();
+
+            BridgeIngressSpec bridgeIngressSpec = new BridgeIngressSpec();
+            bridgeIngressSpec.setImage(imageName);
+            bridgeIngressSpec.setBridgeName(bridgeName);
+            bridgeIngressSpec.setCustomerId(customerId);
+            bridgeIngressSpec.setId(bridgeId);
+
+            BridgeIngress bridgeIngress = new BridgeIngress();
+            bridgeIngress.setSpec(bridgeIngressSpec);
+            bridgeIngress.setMetadata(meta);
+
+            return bridgeIngress;
+        }
+
+        private void validate() {
+            Objects.requireNonNull(Strings.emptyToNull(this.customerId), "[BridgeIngress] CustomerId can't be null");
+            Objects.requireNonNull(Strings.emptyToNull(this.bridgeId), "[BridgeIngress] Id can't be null");
+            Objects.requireNonNull(Strings.emptyToNull(this.imageName), "[BridgeIngress] Ingress Image Name can't be null");
+            Objects.requireNonNull(Strings.emptyToNull(this.bridgeName), "[BridgeIngress] Name can't be null");
+            Objects.requireNonNull(Strings.emptyToNull(this.namespace), "[BridgeIngress] Namespace can't be null");
+        }
     }
 }

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/BridgeIngressServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/BridgeIngressServiceTest.java
@@ -55,7 +55,7 @@ public class BridgeIngressServiceTest {
         BridgeIngress bridgeIngress = kubernetesClient
                 .resources(BridgeIngress.class)
                 .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
-                .withName(BridgeIngress.buildResourceName(dto.getId()))
+                .withName(BridgeIngress.resolveResourceName(dto.getId()))
                 .get();
         assertThat(bridgeIngress).isNotNull();
     }
@@ -77,7 +77,7 @@ public class BridgeIngressServiceTest {
                             // The deployment is deployed by the controller
                             Deployment deployment = kubernetesClient.apps().deployments()
                                     .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
-                                    .withName(BridgeIngress.buildResourceName(dto.getId()))
+                                    .withName(BridgeIngress.resolveResourceName(dto.getId()))
                                     .get();
                             assertThat(deployment).isNotNull();
                             List<EnvVar> environmentVariables = deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
@@ -103,7 +103,7 @@ public class BridgeIngressServiceTest {
         BridgeIngress bridgeIngress = kubernetesClient
                 .resources(BridgeIngress.class)
                 .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
-                .withName(BridgeIngress.buildResourceName(dto.getId()))
+                .withName(BridgeIngress.resolveResourceName(dto.getId()))
                 .get();
         assertThat(bridgeIngress).isNull();
     }
@@ -123,7 +123,7 @@ public class BridgeIngressServiceTest {
                         () -> {
                             Deployment deployment = kubernetesClient.apps().deployments()
                                     .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
-                                    .withName(BridgeIngress.buildResourceName(dto.getId()))
+                                    .withName(BridgeIngress.resolveResourceName(dto.getId()))
                                     .get();
                             assertThat(deployment).isNotNull();
                         });
@@ -137,7 +137,7 @@ public class BridgeIngressServiceTest {
                         () -> {
                             Deployment deployment = kubernetesClient.apps().deployments()
                                     .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
-                                    .withName(BridgeIngress.buildResourceName(dto.getId()))
+                                    .withName(BridgeIngress.resolveResourceName(dto.getId()))
                                     .get();
                             assertThat(deployment).isNull();
                         });

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceTest.java
@@ -73,8 +73,8 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
         managerSyncService.fetchAndProcessBridgesToDeployOrDelete().await().atMost(Duration.ofSeconds(5));
 
         String customerNamespace = customerNamespaceProvider.resolveName(TestConstants.CUSTOMER_ID);
-        String firstBridgeName = BridgeIngress.buildResourceName("myId-1");
-        String secondBridgeName = BridgeIngress.buildResourceName("myId-2");
+        String firstBridgeName = BridgeIngress.resolveResourceName("myId-1");
+        String secondBridgeName = BridgeIngress.resolveResourceName("myId-2");
         Awaitility.await()
                 .atMost(Duration.ofMinutes(2))
                 .pollInterval(Duration.ofSeconds(5))

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressControllerTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressControllerTest.java
@@ -7,10 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import com.redhat.service.bridge.shard.operator.TestConstants;
 import com.redhat.service.bridge.shard.operator.resources.BridgeIngress;
-import com.redhat.service.bridge.shard.operator.resources.BridgeIngressSpec;
-import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
 
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
@@ -67,24 +64,12 @@ public class BridgeIngressControllerTest {
     }
 
     private BridgeIngress buildBridgeIngress() {
-        BridgeIngressSpec bridgeIngressSpec = new BridgeIngressSpec();
-        bridgeIngressSpec.setId(TestConstants.BRIDGE_ID);
-        bridgeIngressSpec.setBridgeName(TestConstants.BRIDGE_NAME);
-        bridgeIngressSpec.setImage(TestConstants.INGRESS_IMAGE);
-        bridgeIngressSpec.setCustomerId(TestConstants.CUSTOMER_ID);
-
-        BridgeIngress bridgeIngress = new BridgeIngress();
-        bridgeIngress.setMetadata(
-                new ObjectMetaBuilder()
-                        .withName(BridgeIngress.buildResourceName(TestConstants.BRIDGE_ID))
-                        .withNamespace(KubernetesResourceUtil.sanitizeName(TestConstants.CUSTOMER_ID))
-                        .withLabels(new LabelsBuilder()
-                                .withCustomerId(TestConstants.CUSTOMER_ID)
-                                .withComponent("ingress")
-                                .build())
-                        .build());
-        bridgeIngress.setSpec(bridgeIngressSpec);
-
-        return bridgeIngress;
+        return BridgeIngress.fromBuilder()
+                .withBridgeId(TestConstants.BRIDGE_ID)
+                .withBridgeName(TestConstants.BRIDGE_NAME)
+                .withImageName(TestConstants.INGRESS_IMAGE)
+                .withCustomerId(TestConstants.CUSTOMER_ID)
+                .withNamespace(KubernetesResourceUtil.sanitizeName(TestConstants.CUSTOMER_ID))
+                .build();
     }
 }

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderTest.java
@@ -7,7 +7,6 @@ import com.redhat.service.bridge.shard.operator.resources.BridgeIngress;
 import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -18,7 +17,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TemplateProviderTest {
 
-    private static final BridgeIngress BRIDGE_INGRESS = buildBridgeIngress();
+    private static final BridgeIngress BRIDGE_INGRESS = BridgeIngress.fromBuilder()
+            .withBridgeName("id")
+            .withNamespace("ns")
+            .withImageName("image:latest")
+            .withBridgeId("12345")
+            .withCustomerId("12456")
+            .build();
 
     @Test
     public void bridgeIngressDeploymentTemplateIsProvided() {
@@ -86,15 +91,4 @@ public class TemplateProviderTest {
         assertThat(ownerReference.getUid()).isEqualTo(bridgeIngress.getMetadata().getUid());
     }
 
-    private static BridgeIngress buildBridgeIngress() {
-        ObjectMeta meta = new ObjectMetaBuilder()
-                .withName("id")
-                .withNamespace("ns")
-                .build();
-
-        BridgeIngress bridgeIngress = new BridgeIngress();
-        bridgeIngress.setMetadata(meta);
-
-        return bridgeIngress;
-    }
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

[MGDOBR-156](https://issues.redhat.com/browse/MGDOBR-156) 

Small refactoring for `BridgeIngress` CR builder. Unfortunately, we can't have a private constructor since fabric8 creates the CR via reflection and needs the public constructor. Our internal client code was refactored to use the builder instead since this object is quite hard to create and keep track of.

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
