### PR TITLE
MGDOBR-147: Create basic test suite for Shard operator integration tests

### DIFF
--- a/.github/workflows/Operator-CI.yaml
+++ b/.github/workflows/Operator-CI.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - 'shard-operator/**'
+      - 'shard-operator-integration-tests/**'
 jobs:
   event-bridge-build:
     env:
@@ -62,6 +63,10 @@ jobs:
           kubectl apply -f shard-operator/target/kubernetes/bridgeexecutors.com.redhat.service.bridge-v1.yml
           kubectl apply -f shard-operator/target/kubernetes/minikube.yml
           kubectl wait --for=condition=available --timeout=60s deployment/shard-operator -n $NAMESPACE
+      - name: Run integration tests
+        shell: bash
+        working-directory: shard-operator-integration-tests
+        run: mvn clean verify -Pcucumber
       - name: Print operator log
         if: always()
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <module>manager</module>
     <module>executor</module>
     <module>shard-operator</module>
+    <module>shard-operator-integration-tests</module>
     <module>integration-tests</module>
     <module>ingress</module>
     <module>infra</module>

--- a/shard-operator-integration-tests/README.md
+++ b/shard-operator-integration-tests/README.md
@@ -1,0 +1,18 @@
+# Shard Operator Integration Tests
+
+Module contains integration tests verifying Shard operator functionality in real cluster. The tests are executed using command `mvn clean verify -Pcucumber`.
+
+Prerequisites for running the tests:
+
+1. Cluster is up and running
+2. Ingress is installed in the cluster
+3. Shard operator is installed in cluster
+4. Local kubeconfig in initialized and connected to the cluster (i.e. local execution of `kubectl cluster-info` is able to reach the cluster and return cluster info)
+
+Tests are implemented using [Cucumber-JVM](https://github.com/cucumber/cucumber-jvm), test scenarios are written using [Gherkin syntax](https://cucumber.io/docs/gherkin/reference/).
+
+Every test scenario runs in a dedicated namespace which is deleted after the test execution. If user terminates test execution prematurely (CTRL + C) then namespace is not deleted automatically, needs to be deleted by user.
+
+## Supported Maven parameters:
+- `tags`: Used to specify a single scenario to be executed. Set the parameter to (for example) `@wip` and annotate a scenario which you want to execute by same tag (`@wip`).
+- `parallel`: User to allow running tests in parallel.

--- a/shard-operator-integration-tests/pom.xml
+++ b/shard-operator-integration-tests/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>com.redhat.service.bridge</groupId>
+    <artifactId>build-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../build-parent/pom.xml</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>shard-operator-integration-tests</artifactId>
+  <name>Event Bridge :: Shard Operator Integration Tests (Cucumber)</name>
+
+  <properties>
+    <cucumber.version>7.0.0</cucumber.version>
+    <parallel>false</parallel>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.redhat.service.bridge</groupId>
+      <artifactId>shard-operator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-java</artifactId>
+      <scope>test</scope>
+      <version>${cucumber.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-junit-platform-engine</artifactId>
+      <scope>test</scope>
+      <version>${cucumber.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.cucumber</groupId>
+        <artifactId>cucumber-picocontainer</artifactId>
+        <scope>test</scope>
+        <version>${cucumber.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Skip Surefire plugin as this module contains only integration tests. -->
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>cucumber</id>
+      <build>
+        <plugins>
+          <!-- Execute suite using the Failsafe plugin as the suite represents integration tests. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <includes>
+                <include>**/*Test.java</include>
+              </includes>
+              <systemProperties>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <cucumber.filter.tags>${tags}</cucumber.filter.tags>
+                <cucumber.execution.parallel.enabled>${parallel}</cucumber.execution.parallel.enabled>
+              </systemProperties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/RunCucumberTest.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/RunCucumberTest.java
@@ -1,0 +1,17 @@
+package com.redhat.service.bridge.shard.operator.cucumber;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
+// For transitive step packages
+//@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.redhat.service.bridge.shard.operator.cucumber")
+public class RunCucumberTest {
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/Context.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/Context.java
@@ -1,0 +1,26 @@
+package com.redhat.service.bridge.shard.operator.cucumber.common;
+
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+/**
+ * Shared scenario context
+ */
+public class Context {
+
+    private String namespace;
+    private OpenShiftClient oc;
+
+    public Context() {
+        namespace = GlobalContext.getUniqueNamespaceName();
+        oc = new DefaultOpenShiftClient();
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public OpenShiftClient getClient() {
+        return oc;
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/GlobalContext.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/GlobalContext.java
@@ -1,0 +1,28 @@
+package com.redhat.service.bridge.shard.operator.cucumber.common;
+
+import java.util.HashSet;
+import java.util.Random;
+
+/**
+ * Shared global context
+ */
+public class GlobalContext {
+
+    /**
+     * Used to make sure that generated namespace names are unique.
+     */
+    private static HashSet<String> usedNamespaces = new HashSet<>();
+    private static Random random = new Random();
+
+    public static synchronized String getUniqueNamespaceName() {
+        // If unique namespace is not created after 10 tries then something is probably wrong, throw an exception
+        for (int i = 0; i < 10; i++) {
+            String generatedNamespace = String.format("bdd-%04d", random.nextInt(10000));
+            if (!usedNamespaces.contains(generatedNamespace)) {
+                usedNamespaces.add(generatedNamespace);
+                return generatedNamespace;
+            }
+        }
+        throw new RuntimeException("Unable to generate unique namespace name");
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/TimeUtils.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/TimeUtils.java
@@ -1,0 +1,38 @@
+package com.redhat.service.bridge.shard.operator.cucumber.common;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
+
+public final class TimeUtils {
+
+    private static final Duration DEFAULT_WAIT_STEP = Duration.of(1, ChronoUnit.SECONDS);
+
+    private TimeUtils() {
+    }
+
+    public static void wait(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Waiting was interrupted", e);
+        }
+    }
+
+    public static void waitForCondition(Duration maxTime, BooleanSupplier conditionSupplier, String timeoutMessage) throws TimeoutException {
+        waitForCondition(maxTime, DEFAULT_WAIT_STEP, conditionSupplier, timeoutMessage);
+    }
+
+    public static void waitForCondition(Duration maxDuration, Duration waitStep, BooleanSupplier conditionSupplier, String timeoutMessage) throws TimeoutException {
+        Instant startTime = Instant.now();
+        while (startTime.plus(maxDuration).isAfter(Instant.now()) && !conditionSupplier.getAsBoolean()) {
+            wait(waitStep);
+        }
+
+        if (!conditionSupplier.getAsBoolean()) {
+            throw new TimeoutException(timeoutMessage);
+        }
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/BridgeIngressSteps.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/BridgeIngressSteps.java
@@ -1,0 +1,73 @@
+package com.redhat.service.bridge.shard.operator.cucumber.steps;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
+import com.redhat.service.bridge.shard.operator.cucumber.common.Context;
+import com.redhat.service.bridge.shard.operator.cucumber.common.TimeUtils;
+import com.redhat.service.bridge.shard.operator.resources.BridgeIngress;
+
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+/**
+ * Step definitions related to BridgeIngress
+ */
+public class BridgeIngressSteps {
+
+    private Context context;
+
+    public BridgeIngressSteps(Context context) {
+        this.context = context;
+    }
+
+    @When("^deploy BridgeIngress:$")
+    public void deployBridgeIngress(String bridgeIngressYaml) {
+        InputStream resourceStream = new ByteArrayInputStream(bridgeIngressYaml.getBytes(StandardCharsets.UTF_8));
+        context.getClient().resources(BridgeIngress.class).inNamespace(context.getNamespace()).load(resourceStream).createOrReplace();
+    }
+
+    @When("^delete BridgeIngress \"([^\"]*)\"$")
+    public void deleteBridgeIngress(String name) {
+        Boolean deleted = context.getClient().resources(BridgeIngress.class).inNamespace(context.getNamespace()).withName(name).delete();
+        if (deleted == null || !deleted) {
+            throw new IllegalArgumentException(String.format("BridgeIngress '%s' not found, cannot be deleted", name));
+        }
+    }
+
+    @Then("^the BridgeIngress \"([^\"]*)\" exists within (\\d+) (?:minute|minutes)$")
+    public void theBridgeIngressExistsWithinMinutes(String name, int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    BridgeIngress bridgeIngress = context.getClient().resources(BridgeIngress.class).inNamespace(context.getNamespace()).withName(name).get();
+                    return bridgeIngress != null;
+                },
+                String.format("Timeout waiting for BridgeIngress '%s' to exist in namespace '%s'", name, context.getNamespace()));
+    }
+
+    @Then("^the BridgeIngress \"([^\"]*)\" does not exist within (\\d+) (?:minute|minutes)$")
+    public void theBridgeIngressDoesNotExistWithinMinutes(String name, int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    BridgeIngress bridgeIngress = context.getClient().resources(BridgeIngress.class).inNamespace(context.getNamespace()).withName(name).get();
+                    return bridgeIngress == null;
+                },
+                String.format("Timeout waiting for BridgeIngress '%s' to not exist in namespace '%s'", name, context.getNamespace()));
+    }
+
+    @Then("^the BridgeIngress \"([^\"]*)\" is in phase \"([^\"]*)\" within (\\d+) (?:minute|minutes)$")
+    public void theBridgeIngressIsInPhaseWithinMinutes(String name, String phase, int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    BridgeIngress bridgeIngress = context.getClient().resources(BridgeIngress.class).inNamespace(context.getNamespace()).withName(name).get();
+                    if (bridgeIngress == null || bridgeIngress.getStatus() == null) {
+                        return false;
+                    }
+                    return bridgeIngress.getStatus().getPhase().toString().equals(phase);
+                },
+                String.format("Timeout waiting for BridgeIngress '%s' to be in phase '%s' in namespace '%s'", name, phase, context.getNamespace()));
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/Hooks.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/Hooks.java
@@ -1,0 +1,24 @@
+package com.redhat.service.bridge.shard.operator.cucumber.steps;
+
+import java.io.FileNotFoundException;
+
+import com.redhat.service.bridge.shard.operator.cucumber.common.Context;
+
+import io.cucumber.java.After;
+
+/**
+ * Cucumber hooks for setup and cleanup
+ */
+public class Hooks {
+
+    private Context context;
+
+    public Hooks(Context context) {
+        this.context = context;
+    }
+
+    @After
+    public void cleanupNamespaceAfterScenario() throws FileNotFoundException {
+        context.getClient().namespaces().withName(context.getNamespace()).delete();
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/KubernetesSteps.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/KubernetesSteps.java
@@ -1,0 +1,105 @@
+package com.redhat.service.bridge.shard.operator.cucumber.steps;
+
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
+import com.redhat.service.bridge.shard.operator.cucumber.common.Context;
+import com.redhat.service.bridge.shard.operator.cucumber.common.TimeUtils;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentList;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressList;
+
+/**
+ * Step definitions related to Kubernetes
+ */
+public class KubernetesSteps {
+
+    private Context context;
+
+    public KubernetesSteps(Context context) {
+        this.context = context;
+    }
+
+    @Given("^create Namespace$")
+    public void createNamespace() {
+        context.getClient().namespaces().createOrReplace(
+                new NamespaceBuilder()
+                        .withNewMetadata()
+                        .withName(context.getNamespace())
+                        .endMetadata()
+                        .build());
+    }
+
+    @Then("^the Deployment \"([^\"]*)\" is ready within (\\d+) (?:minute|minutes)$")
+    public void theDeploymentIsInStateWithinMinutes(String name, int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    Deployment deployment = context.getClient().apps().deployments().inNamespace(context.getNamespace()).withName(name).get();
+                    if (deployment == null) {
+                        return false;
+                    }
+                    return deployment.getStatus().getConditions().stream().anyMatch(d -> d.getType().equals("Available") && d.getStatus().equals("True"));
+                },
+                String.format("Timeout waiting for Deployment '%s' to be ready in namespace '%s'", name, context.getNamespace()));
+    }
+
+    @Then("^no Deployment exists within (\\d+) (?:minute|minutes)$")
+    public void noDeploymentExistsWithinMinutes(int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    DeploymentList deployments = context.getClient().apps().deployments().inNamespace(context.getNamespace()).list();
+                    return deployments.getItems().isEmpty();
+                },
+                String.format("Timeout waiting for all Deployments to be removed", context.getNamespace()));
+    }
+
+    @Then("^the Service \"([^\"]*)\" exists within (\\d+) (?:minute|minutes)$")
+    public void theServiceExistsWithinMinutes(String name, int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    Service service = context.getClient().services().inNamespace(context.getNamespace()).withName(name).get();
+                    return service != null;
+                },
+                String.format("Timeout waiting for Service '%s' to exist in namespace '%s'", name, context.getNamespace()));
+    }
+
+    @Then("^no Service exists within (\\d+) (?:minute|minutes)$")
+    public void noServiceExistsWithinMinutes(int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    ServiceList services = context.getClient().services().inNamespace(context.getNamespace()).list();
+                    return services.getItems().isEmpty();
+                },
+                String.format("Timeout waiting for all Services to be removed", context.getNamespace()));
+    }
+
+    @Then("^the Ingress \"([^\"]*)\" is ready within (\\d+) (?:minute|minutes)$")
+    public void theIngressExistsWithinMinutes(String name, int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    Ingress ingress = context.getClient().network().v1().ingresses().inNamespace(context.getNamespace()).withName(name).get();
+                    if (ingress == null) {
+                        return false;
+                    }
+                    return ingress.getStatus() != null;
+                },
+                String.format("Timeout waiting for Ingress '%s' to be ready in namespace '%s'", name, context.getNamespace()));
+    }
+
+    @Then("^no Ingress exists within (\\d+) (?:minute|minutes)$")
+    public void noIngressExistsWithinMinutes(int timeoutInMinutes) throws TimeoutException {
+        TimeUtils.waitForCondition(Duration.ofMinutes(timeoutInMinutes),
+                () -> {
+                    IngressList ingresses = context.getClient().network().v1().ingresses().inNamespace(context.getNamespace()).list();
+                    return ingresses.getItems().isEmpty();
+                },
+                String.format("Timeout waiting for all Ingresses to be removed", context.getNamespace()));
+    }
+}

--- a/shard-operator-integration-tests/src/test/resources/features/bridgeingress-deploy.feature
+++ b/shard-operator-integration-tests/src/test/resources/features/bridgeingress-deploy.feature
@@ -1,0 +1,50 @@
+Feature: BridgeIngress deploy and undeploy
+
+  Background:
+    Given create Namespace
+
+  # Using "dummy" image as real BridgeIngress image requires Kafka
+  Scenario: BridgeIngress is in phase AVAILABLE
+    When deploy BridgeIngress:
+    """
+    apiVersion: com.redhat.service.bridge/v1alpha1
+    kind: BridgeIngress
+    metadata:
+      name: my-bridge-ingress
+      app.kubernetes.io/managed-by: bridge-fleet-shard-operator
+    spec:
+      image: nginx:1.14.2
+      bridgeName: my-bridge
+      customerId: customer
+      id: my-bridge-ingress
+    """
+     
+     Then the BridgeIngress "my-bridge-ingress" exists within 1 minute
+     And the Deployment "my-bridge-ingress" is ready within 1 minute
+     And the Service "my-bridge-ingress" exists within 1 minute
+     And the Ingress "my-bridge-ingress" is ready within 1 minute
+     And the BridgeIngress "my-bridge-ingress" is in phase "AVAILABLE" within 2 minutes
+
+  # Using "dummy" image as real BridgeIngress image requires Kafka
+  Scenario: BridgeIngress gets deleted
+    Given deploy BridgeIngress:
+    """
+    apiVersion: com.redhat.service.bridge/v1alpha1
+    kind: BridgeIngress
+    metadata:
+      name: my-deleted-bridge-ingress
+      app.kubernetes.io/managed-by: bridge-fleet-shard-operator
+    spec:
+      image: nginx:1.14.2
+      bridgeName: my-bridge
+      customerId: customer
+      id: my-bridge-ingress
+    """
+    And the BridgeIngress "my-deleted-bridge-ingress" is in phase "AVAILABLE" within 2 minutes
+
+    When delete BridgeIngress "my-deleted-bridge-ingress"
+     
+    Then the BridgeIngress "my-deleted-bridge-ingress" does not exist within 1 minute
+    And no Deployment exists within 1 minute
+    And no Service exists within 1 minute
+    And no Ingress exists within 1 minute

--- a/shard-operator-integration-tests/src/test/resources/junit-platform.properties
+++ b/shard-operator-integration-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+cucumber.publish.quiet=true

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/networking/KubernetesNetworkingService.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/networking/KubernetesNetworkingService.java
@@ -99,7 +99,8 @@ public class KubernetesNetworkingService implements NetworkingService {
 
     private NetworkResource buildNetworkingResource(Ingress ingress) {
         if (ingress.getStatus() == null || ingress.getStatus().getLoadBalancer() == null || ingress.getStatus().getLoadBalancer().getIngress() == null
-                || ingress.getStatus().getLoadBalancer().getIngress().isEmpty() || ingress.getStatus().getLoadBalancer().getIngress().get(0).getIp() == null) {
+                || ingress.getStatus().getLoadBalancer().getIngress().isEmpty()
+                || (ingress.getStatus().getLoadBalancer().getIngress().get(0).getIp() == null && ingress.getStatus().getLoadBalancer().getIngress().get(0).getHostname() == null)) {
             LOGGER.info("Ingress {} not ready yet", ingress.getMetadata().getName());
             return new NetworkResource("", false);
         }


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

[MGDOBR-147](https://issues.redhat.com/browse/MGDOBR-147) 

Initial implementation of Shard operator integration tests.
The tests focus specifically on operator functionality, the BridgeIngress images were replaced with dummy ones as original images require Kafka - is currently not available for CI tests.

@r00ta  Currently integration tests aren't added to parent module list as the integration tests are executed by default there. Running this module without prepared environment will cause test failures. Would it have more sense to add the module into module list, allowing tests to be executed only when parameter/profile is activated?

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
