### PR TITLE
MGDOBR-39: Remove BridgeDTO from ProcessorDTO and ProcessorResponse

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -127,7 +127,6 @@ and the response is something like
   "kind":"Processor",
   "href":"/api/v1/bridges/87508471-ee0f-4f53-b574-da8a61285986/processors/cad90605-9836-4378-9250-f9c8d19f4e0c",
   "name":"myProcessor",
-  "bridge":{"kind":"Bridge","id":"87508471-ee0f-4f53-b574-da8a61285986","name":"myBridge","href":"/api/v1/bridges/87508471-ee0f-4f53-b574-da8a61285986","submitted_at":"2021-09-24T11:29:33.086649+0000","status":"AVAILABLE","endpoint":"/ingress/events/87508471-ee0f-4f53-b574-da8a61285986"},
   "submitted_at":"2021-09-24T11:49:47.170209+0000",
   "status":"REQUESTED",
   "filters": 

--- a/actions/src/main/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicAction.java
+++ b/actions/src/main/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicAction.java
@@ -54,18 +54,18 @@ public class KafkaTopicAction implements InvokableActionProvider {
         String requiredTopic = baseAction.getParameters().get(TOPIC_PARAM);
         if (requiredTopic == null) {
             throw new ActionProviderException(
-                    String.format("There is no topic specified in the parameters for Action on Processor '%s' on Bridge '%s'", processor.getId(), processor.getBridge().getId()));
+                    String.format("There is no topic specified in the parameters for Action on Processor '%s' on Bridge '%s'", processor.getId(), processor.getBridgeId()));
         }
 
         try {
             Set<String> strings = adminClient.listTopics().names().get(DEFAULT_LIST_TOPICS_TIMEOUT, DEFAULT_LIST_TOPICS_TIMEUNIT);
             if (!strings.contains(requiredTopic)) {
                 throw new ActionProviderException(
-                        String.format("The requested topic '%s' for Action on Processor '%s' for bridge '%s' does not exist", requiredTopic, processor.getId(), processor.getBridge().getId()));
+                        String.format("The requested topic '%s' for Action on Processor '%s' for bridge '%s' does not exist", requiredTopic, processor.getId(), processor.getBridgeId()));
             }
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new ActionProviderException(String.format("Unable to list topics from Kafka to check requested topic '%s' exists for Action on Processor '%s' on bridge '%s'", requiredTopic,
-                    processor.getId(), processor.getBridge().getId()), e);
+                    processor.getId(), processor.getBridgeId()), e);
         }
 
         return new KafkaTopicInvoker(emitter, processor, requiredTopic);

--- a/actions/src/main/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicInvoker.java
+++ b/actions/src/main/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicInvoker.java
@@ -38,6 +38,6 @@ public class KafkaTopicInvoker implements ActionInvoker {
                 .withTopic(topic)
                 .build();
         emitter.send(Message.of(event).addMetadata(metadata));
-        LOG.info("Emitted CloudEvent to target topic '{}' for Action on Processor '{}' on Bridge '{}'", topic, processor.getId(), processor.getBridge().getId());
+        LOG.info("Emitted CloudEvent to target topic '{}' for Action on Processor '{}' on Bridge '{}'", topic, processor.getId(), processor.getBridgeId());
     }
 }

--- a/actions/src/main/java/com/redhat/service/bridge/actions/webhook/WebhookAction.java
+++ b/actions/src/main/java/com/redhat/service/bridge/actions/webhook/WebhookAction.java
@@ -53,7 +53,7 @@ public class WebhookAction implements InvokableActionProvider {
 
     private ActionProviderException buildNoEndpointException(ProcessorDTO processor) {
         String message = String.format("There is no endpoint specified in the parameters for Action on Processor '%s' on Bridge '%s'",
-                processor.getId(), processor.getBridge().getId());
+                processor.getId(), processor.getBridgeId());
         return new ActionProviderException(message);
     }
 }

--- a/actions/src/test/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicActionTest.java
+++ b/actions/src/test/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicActionTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import com.redhat.service.bridge.actions.ActionInvoker;
 import com.redhat.service.bridge.actions.ActionProviderException;
 import com.redhat.service.bridge.infra.models.actions.BaseAction;
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.processors.ProcessorDefinition;
 
@@ -61,10 +60,7 @@ public class KafkaTopicActionTest {
         ProcessorDTO p = new ProcessorDTO();
         p.setId("myProcessor");
         p.setDefinition(new ProcessorDefinition(null, null, b));
-
-        BridgeDTO bridge = new BridgeDTO();
-        bridge.setId("myBridge");
-        p.setBridge(bridge);
+        p.setBridgeId("myBridge");
 
         return p;
     }

--- a/actions/src/test/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicActionValidatorTest.java
+++ b/actions/src/test/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicActionValidatorTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import com.redhat.service.bridge.actions.ValidationResult;
 import com.redhat.service.bridge.infra.models.actions.BaseAction;
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.processors.ProcessorDefinition;
 
@@ -33,10 +32,7 @@ public class KafkaTopicActionValidatorTest {
         ProcessorDTO p = new ProcessorDTO();
         p.setId("myProcessor");
         p.setDefinition(new ProcessorDefinition(null, null, b));
-
-        BridgeDTO bridge = new BridgeDTO();
-        bridge.setId("myBridge");
-        p.setBridge(bridge);
+        p.setBridgeId("myBridge");
 
         return p;
     }

--- a/actions/src/test/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicInvokerTest.java
+++ b/actions/src/test/java/com/redhat/service/bridge/actions/kafkatopic/KafkaTopicInvokerTest.java
@@ -6,7 +6,6 @@ import org.eclipse.microprofile.reactive.messaging.Metadata;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 
 import io.smallrye.reactive.messaging.kafka.api.OutgoingKafkaRecordMetadata;
@@ -20,10 +19,7 @@ public class KafkaTopicInvokerTest {
     private ProcessorDTO createProcessor() {
         ProcessorDTO p = new ProcessorDTO();
         p.setId("myProcessor");
-
-        BridgeDTO b = new BridgeDTO();
-        b.setId("myBridge");
-        p.setBridge(b);
+        p.setBridgeId("myBridge");
         return p;
     }
 

--- a/actions/src/test/java/com/redhat/service/bridge/actions/webhook/WebhookActionTest.java
+++ b/actions/src/test/java/com/redhat/service/bridge/actions/webhook/WebhookActionTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import com.redhat.service.bridge.actions.ActionInvoker;
 import com.redhat.service.bridge.actions.ActionProviderException;
 import com.redhat.service.bridge.infra.models.actions.BaseAction;
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.processors.ProcessorDefinition;
 
@@ -50,10 +49,7 @@ public class WebhookActionTest {
         ProcessorDTO processor = new ProcessorDTO();
         processor.setId("myProcessor");
         processor.setDefinition(new ProcessorDefinition(null, null, action));
-
-        BridgeDTO bridge = new BridgeDTO();
-        bridge.setId("myBridge");
-        processor.setBridge(bridge);
+        processor.setBridgeId("myBridge");
 
         return processor;
     }

--- a/executor/src/main/java/com/redhat/service/bridge/executor/Executor.java
+++ b/executor/src/main/java/com/redhat/service/bridge/executor/Executor.java
@@ -57,7 +57,7 @@ public class Executor {
 
     @SuppressWarnings("unchecked")
     private void process(CloudEvent cloudEvent) {
-        LOG.info("[executor] Received event with id '{}' for Processor with name '{}' on Bridge '{}", cloudEvent.getId(), processor.getName(), processor.getBridge().getId());
+        LOG.info("[executor] Received event with id '{}' for Processor with name '{}' on Bridge '{}", cloudEvent.getId(), processor.getName(), processor.getBridgeId());
 
         Map<String, Object> cloudEventData = CloudEventUtils.getMapper().convertValue(cloudEvent, Map.class);
 
@@ -99,7 +99,7 @@ public class Executor {
 
     private void initMetricFields(ProcessorDTO processor, MeterRegistry registry) {
         List<Tag> tags = Arrays.asList(
-                Tag.of(MetricsConstants.BRIDGE_ID_TAG, processor.getBridge().getId()), Tag.of(MetricsConstants.PROCESSOR_ID_TAG, processor.getId()));
+                Tag.of(MetricsConstants.BRIDGE_ID_TAG, processor.getBridgeId()), Tag.of(MetricsConstants.PROCESSOR_ID_TAG, processor.getId()));
         this.processorProcessingTime = registry.timer(MetricsConstants.PROCESSOR_PROCESSING_TIME_METRIC_NAME, tags);
         this.filterTimer = registry.timer(MetricsConstants.FILTER_PROCESSING_TIME_METRIC_NAME, tags);
         this.actionTimer = registry.timer(MetricsConstants.ACTION_PROCESSING_TIME_METRIC_NAME, tags);

--- a/executor/src/main/java/com/redhat/service/bridge/executor/ExecutorsService.java
+++ b/executor/src/main/java/com/redhat/service/bridge/executor/ExecutorsService.java
@@ -42,13 +42,13 @@ public class ExecutorsService {
             BridgeCloudEventExtension bridgeCloudEventExtension = ExtensionProvider.getInstance().parseExtension(BridgeCloudEventExtension.class, cloudEvent);
             String bridgeId = bridgeCloudEventExtension.getBridgeId();
             Executor executor = executorsProvider.getExecutor();
-            if (executor.getProcessor().getBridge().getId().equals(bridgeId)) {
+            if (executor.getProcessor().getBridgeId().equals(bridgeId)) {
                 try {
                     executor.onEvent(cloudEvent);
                 } catch (Throwable t) {
                     // Inner Throwable catch is to provide more specific context around which Executor failed to handle the Event, rather than a generic failure
                     LOG.error("[executor] Processor with id '{}' on bridge '{}' failed to handle Event. The message is acked anyway.", executor.getProcessor().getId(),
-                            executor.getProcessor().getBridge().getId(), t);
+                            executor.getProcessor().getBridgeId(), t);
                 }
             }
         } catch (Throwable t) {

--- a/executor/src/test/java/com/redhat/service/bridge/executor/ExecutorServiceTest.java
+++ b/executor/src/test/java/com/redhat/service/bridge/executor/ExecutorServiceTest.java
@@ -47,7 +47,7 @@ public class ExecutorServiceTest {
         when(bridgeDTO.getId()).thenReturn(BRIDGE_ID);
 
         ProcessorDTO processorDTO = mock(ProcessorDTO.class);
-        when(processorDTO.getBridge()).thenReturn(bridgeDTO);
+        when(processorDTO.getBridgeId()).thenReturn(BRIDGE_ID);
 
         when(executor.getProcessor()).thenReturn(processorDTO);
         when(executorsProvider.getExecutor()).thenReturn(executor);

--- a/executor/src/test/java/com/redhat/service/bridge/executor/ExecutorTest.java
+++ b/executor/src/test/java/com/redhat/service/bridge/executor/ExecutorTest.java
@@ -19,7 +19,6 @@ import com.redhat.service.bridge.executor.filters.FilterEvaluatorFactoryFEEL;
 import com.redhat.service.bridge.executor.transformations.TransformationEvaluatorFactory;
 import com.redhat.service.bridge.executor.transformations.TransformationEvaluatorFactoryQute;
 import com.redhat.service.bridge.infra.models.actions.BaseAction;
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.BridgeStatus;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.filters.BaseFilter;
@@ -189,8 +188,6 @@ public class ExecutorTest {
     }
 
     protected ProcessorDTO createProcessor(ProcessorDefinition definition) {
-        BridgeDTO bridgeDTO = new BridgeDTO("bridgeId-1", "bridgeName-1", "test", "jrota", BridgeStatus.AVAILABLE);
-        return new ProcessorDTO("processorId-1", "processorName-1", definition, bridgeDTO, BridgeStatus.AVAILABLE);
+        return new ProcessorDTO("processorId-1", "processorName-1", definition, "bridgeId-1", "jrota", BridgeStatus.AVAILABLE);
     }
-
 }

--- a/infra/src/main/java/com/redhat/service/bridge/infra/models/dto/ProcessorDTO.java
+++ b/infra/src/main/java/com/redhat/service/bridge/infra/models/dto/ProcessorDTO.java
@@ -16,8 +16,11 @@ public class ProcessorDTO {
     @JsonProperty("definition")
     private ProcessorDefinition definition;
 
-    @JsonProperty("bridge")
-    private BridgeDTO bridge;
+    @JsonProperty("bridgeId")
+    private String bridgeId;
+
+    @JsonProperty("customerId")
+    private String customerId;
 
     @JsonProperty("status")
     private BridgeStatus status;
@@ -25,10 +28,11 @@ public class ProcessorDTO {
     public ProcessorDTO() {
     }
 
-    public ProcessorDTO(String id, String name, ProcessorDefinition definition, BridgeDTO bridge, BridgeStatus status) {
+    public ProcessorDTO(String id, String name, ProcessorDefinition definition, String bridgeId, String customerId, BridgeStatus status) {
         this.id = id;
         this.name = name;
-        this.bridge = bridge;
+        this.bridgeId = bridgeId;
+        this.customerId = customerId;
         this.status = status;
         this.definition = definition;
     }
@@ -57,12 +61,20 @@ public class ProcessorDTO {
         this.definition = definition;
     }
 
-    public BridgeDTO getBridge() {
-        return bridge;
+    public String getBridgeId() {
+        return bridgeId;
     }
 
-    public void setBridge(BridgeDTO bridge) {
-        this.bridge = bridge;
+    public void setBridgeId(String bridgeId) {
+        this.bridgeId = bridgeId;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(String customerId) {
+        this.customerId = customerId;
     }
 
     public BridgeStatus getStatus() {

--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/End2EndTestIT.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/End2EndTestIT.java
@@ -182,7 +182,8 @@ public class End2EndTestIT {
         assertThat(response.getName()).isEqualTo(PROCESSOR_NAME);
         assertThat(response.getKind()).isEqualTo("Processor");
         assertThat(response.getHref()).isNotNull();
-        assertThat(response.getBridge()).isNotNull();
+        assertThat(response.getBridgeId()).isNotNull();
+        assertThat(response.getCustomerId()).isNotNull();
         assertThat(response.getStatus()).isEqualTo(BridgeStatus.REQUESTED);
         assertThat(response.getFilters().size()).isEqualTo(1);
 

--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/End2EndTestIT.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/End2EndTestIT.java
@@ -183,7 +183,6 @@ public class End2EndTestIT {
         assertThat(response.getKind()).isEqualTo("Processor");
         assertThat(response.getHref()).isNotNull();
         assertThat(response.getBridgeId()).isNotNull();
-        assertThat(response.getCustomerId()).isNotNull();
         assertThat(response.getStatus()).isEqualTo(BridgeStatus.REQUESTED);
         assertThat(response.getFilters().size()).isEqualTo(1);
 

--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/End2EndTestIT.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/End2EndTestIT.java
@@ -182,7 +182,6 @@ public class End2EndTestIT {
         assertThat(response.getName()).isEqualTo(PROCESSOR_NAME);
         assertThat(response.getKind()).isEqualTo("Processor");
         assertThat(response.getHref()).isNotNull();
-        assertThat(response.getBridgeId()).isNotNull();
         assertThat(response.getStatus()).isEqualTo(BridgeStatus.REQUESTED);
         assertThat(response.getFilters().size()).isEqualTo(1);
 

--- a/kustomize/base/shard/resources/bridgeexecutors.com.redhat.service.bridge-v1.yml
+++ b/kustomize/base/shard/resources/bridgeexecutors.com.redhat.service.bridge-v1.yml
@@ -9,61 +9,45 @@ spec:
     kind: BridgeExecutor
     plural: bridgeexecutors
     shortNames:
-    - be
+      - be
     singular: bridgeexecutor
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            properties:
-              id:
-                type: string
-              bridgeDTO:
-                properties:
-                  id:
-                    type: string
-                  status:
-                    enum:
-                    - FAILED
-                    - AVAILABLE
-                    - PROVISIONING
-                    - REQUESTED
-                    - DELETION_REQUESTED
-                    - DELETED
-                    type: string
-                  customerId:
-                    type: string
-                  endpoint:
-                    type: string
-                  name:
-                    type: string
-                type: object
-              image:
-                type: string
-              processorDefinition:
-                type: string
-              processorName:
-                type: string
-            type: object
-          status:
-            properties:
-              conditions:
-                items:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                id:
                   type: string
-                type: array
-              phase:
-                enum:
-                - ERROR
-                - AUGMENTATION
-                - INITIALIZATION
-                - AVAILABLE
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                bridgeId:
+                  type: string
+                customerId:
+                  type: string
+                image:
+                  type: string
+                processorDefinition:
+                  type: string
+                processorName:
+                  type: string
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    type: string
+                  type: array
+                phase:
+                  enum:
+                    - ERROR
+                    - AUGMENTATION
+                    - INITIALIZATION
+                    - AVAILABLE
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorServiceImpl.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorServiceImpl.java
@@ -170,7 +170,6 @@ public class ProcessorServiceImpl implements ProcessorService {
 
         if (processor.getBridge() != null) {
             processorResponse.setHref(APIConstants.USER_API_BASE_PATH + processor.getBridge().getId() + "/processors/" + processor.getId());
-            processorResponse.setBridgeId(processor.getBridge().getId());
         }
 
         return processorResponse;

--- a/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorServiceImpl.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorServiceImpl.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.service.bridge.actions.ActionProviderFactory;
 import com.redhat.service.bridge.infra.api.APIConstants;
 import com.redhat.service.bridge.infra.models.actions.BaseAction;
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.BridgeStatus;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.filters.BaseFilter;
@@ -105,11 +104,11 @@ public class ProcessorServiceImpl implements ProcessorService {
     @Transactional
     @Override
     public Processor updateProcessorStatus(ProcessorDTO processorDTO) {
-        Bridge bridge = bridgesService.getBridge(processorDTO.getBridge().getId());
+        Bridge bridge = bridgesService.getBridge(processorDTO.getBridgeId());
         Processor p = processorDAO.findById(processorDTO.getId());
         if (p == null) {
             throw new ItemNotFoundException(String.format("Processor with id '%s' does not exist for Bridge '%s' for customer '%s'", bridge.getId(), bridge.getCustomerId(),
-                    processorDTO.getBridge().getCustomerId()));
+                    processorDTO.getCustomerId()));
         }
         p.setStatus(processorDTO.getStatus());
 
@@ -148,9 +147,8 @@ public class ProcessorServiceImpl implements ProcessorService {
 
     @Override
     public ProcessorDTO toDTO(Processor processor) {
-        BridgeDTO bridgeDTO = processor.getBridge() != null ? bridgesService.toDTO(processor.getBridge()) : null;
         ProcessorDefinition definition = processor.getDefinition() != null ? jsonNodeToDefinition(processor.getDefinition()) : null;
-        return new ProcessorDTO(processor.getId(), processor.getName(), definition, bridgeDTO, processor.getStatus());
+        return new ProcessorDTO(processor.getId(), processor.getName(), definition, processor.getBridge().getId(), processor.getBridge().getCustomerId(), processor.getStatus());
     }
 
     @Override
@@ -172,7 +170,8 @@ public class ProcessorServiceImpl implements ProcessorService {
 
         if (processor.getBridge() != null) {
             processorResponse.setHref(APIConstants.USER_API_BASE_PATH + processor.getBridge().getId() + "/processors/" + processor.getId());
-            processorResponse.setBridge(bridgesService.toResponse(processor.getBridge()));
+            processorResponse.setBridgeId(processor.getBridge().getId());
+            processorResponse.setCustomerId(processor.getBridge().getCustomerId());
         }
 
         return processorResponse;

--- a/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorServiceImpl.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/ProcessorServiceImpl.java
@@ -171,7 +171,6 @@ public class ProcessorServiceImpl implements ProcessorService {
         if (processor.getBridge() != null) {
             processorResponse.setHref(APIConstants.USER_API_BASE_PATH + processor.getBridge().getId() + "/processors/" + processor.getId());
             processorResponse.setBridgeId(processor.getBridge().getId());
-            processorResponse.setCustomerId(processor.getBridge().getCustomerId());
         }
 
         return processorResponse;

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/internal/ShardBridgesSyncAPI.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/internal/ShardBridgesSyncAPI.java
@@ -41,8 +41,8 @@ public class ShardBridgesSyncAPI {
     @PUT
     @Path("processors")
     public Response updateProcessorStatus(ProcessorDTO processorDTO) {
-        LOGGER.info("Processing update from shard for Processor with id '{}' for bridge '{}' for customer '{}'", processorDTO.getId(), processorDTO.getBridge().getId(),
-                processorDTO.getBridge().getCustomerId());
+        LOGGER.info("Processing update from shard for Processor with id '{}' for bridge '{}' for customer '{}'", processorDTO.getId(), processorDTO.getBridgeId(),
+                processorDTO.getCustomerId());
         processorService.updateProcessorStatus(processorDTO);
         return Response.ok().build();
     }

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorResponse.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorResponse.java
@@ -17,9 +17,6 @@ public class ProcessorResponse extends BaseResponse {
         super("Processor");
     }
 
-    @JsonProperty("bridgeId")
-    private String bridgeId;
-
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")
     @JsonProperty("submitted_at")
     private ZonedDateTime submittedAt;
@@ -39,14 +36,6 @@ public class ProcessorResponse extends BaseResponse {
 
     @JsonProperty("action")
     private BaseAction action;
-
-    public String getBridgeId() {
-        return bridgeId;
-    }
-
-    public void setBridgeId(String bridgeId) {
-        this.bridgeId = bridgeId;
-    }
 
     public ZonedDateTime getSubmittedAt() {
         return submittedAt;

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorResponse.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorResponse.java
@@ -17,8 +17,11 @@ public class ProcessorResponse extends BaseResponse {
         super("Processor");
     }
 
-    @JsonProperty("bridge")
-    private BridgeResponse bridge;
+    @JsonProperty("bridgeId")
+    private String bridgeId;
+
+    @JsonProperty("customerId")
+    private String customerId;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")
     @JsonProperty("submitted_at")
@@ -40,12 +43,20 @@ public class ProcessorResponse extends BaseResponse {
     @JsonProperty("action")
     private BaseAction action;
 
-    public BridgeResponse getBridge() {
-        return bridge;
+    public String getBridgeId() {
+        return bridgeId;
     }
 
-    public void setBridge(BridgeResponse bridge) {
-        this.bridge = bridge;
+    public void setBridgeId(String bridgeId) {
+        this.bridgeId = bridgeId;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(String customerId) {
+        this.customerId = customerId;
     }
 
     public ZonedDateTime getSubmittedAt() {

--- a/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorResponse.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/api/models/responses/ProcessorResponse.java
@@ -20,9 +20,6 @@ public class ProcessorResponse extends BaseResponse {
     @JsonProperty("bridgeId")
     private String bridgeId;
 
-    @JsonProperty("customerId")
-    private String customerId;
-
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ")
     @JsonProperty("submitted_at")
     private ZonedDateTime submittedAt;
@@ -49,14 +46,6 @@ public class ProcessorResponse extends BaseResponse {
 
     public void setBridgeId(String bridgeId) {
         this.bridgeId = bridgeId;
-    }
-
-    public String getCustomerId() {
-        return customerId;
-    }
-
-    public void setCustomerId(String customerId) {
-        this.customerId = customerId;
     }
 
     public ZonedDateTime getSubmittedAt() {

--- a/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.service.bridge.actions.kafkatopic.KafkaTopicAction;
 import com.redhat.service.bridge.infra.api.APIConstants;
 import com.redhat.service.bridge.infra.models.actions.BaseAction;
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.BridgeStatus;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.filters.BaseFilter;
@@ -167,10 +166,8 @@ public class ProcessorServiceTest {
 
     @Test
     public void updateProcessorStatus_bridgeDoesNotExist() {
-        BridgeDTO bridge = new BridgeDTO();
-        bridge.setId("foo");
         ProcessorDTO processor = new ProcessorDTO();
-        processor.setBridge(bridge);
+        processor.setBridgeId("foo");
 
         assertThatExceptionOfType(ItemNotFoundException.class).isThrownBy(() -> processorService.updateProcessorStatus(processor));
     }
@@ -330,7 +327,8 @@ public class ProcessorServiceTest {
         assertThat(r.getSubmittedAt()).isEqualTo(p.getSubmittedAt());
         assertThat(r.getPublishedAt()).isEqualTo(p.getPublishedAt());
         assertThat(r.getKind()).isEqualTo("Processor");
-        assertThat(r.getBridge()).isNotNull();
+        assertThat(r.getBridgeId()).isNotNull();
+        assertThat(r.getCustomerId()).isNotNull();
         assertThat(r.getTransformationTemplate()).isEmpty();
         assertThat(r.getAction().getType()).isEqualTo(KafkaTopicAction.TYPE);
         assertThat(r.getAction().getName()).isEqualTo(TestConstants.DEFAULT_ACTION_NAME);

--- a/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
@@ -328,7 +328,6 @@ public class ProcessorServiceTest {
         assertThat(r.getPublishedAt()).isEqualTo(p.getPublishedAt());
         assertThat(r.getKind()).isEqualTo("Processor");
         assertThat(r.getBridgeId()).isNotNull();
-        assertThat(r.getCustomerId()).isNotNull();
         assertThat(r.getTransformationTemplate()).isEmpty();
         assertThat(r.getAction().getType()).isEqualTo(KafkaTopicAction.TYPE);
         assertThat(r.getAction().getName()).isEqualTo(TestConstants.DEFAULT_ACTION_NAME);

--- a/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/ProcessorServiceTest.java
@@ -327,7 +327,6 @@ public class ProcessorServiceTest {
         assertThat(r.getSubmittedAt()).isEqualTo(p.getSubmittedAt());
         assertThat(r.getPublishedAt()).isEqualTo(p.getPublishedAt());
         assertThat(r.getKind()).isEqualTo("Processor");
-        assertThat(r.getBridgeId()).isNotNull();
         assertThat(r.getTransformationTemplate()).isEmpty();
         assertThat(r.getAction().getType()).isEqualTo(KafkaTopicAction.TYPE);
         assertThat(r.getAction().getName()).isEqualTo(TestConstants.DEFAULT_ACTION_NAME);

--- a/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
@@ -125,7 +125,6 @@ public class ProcessorAPITest {
         ProcessorResponse found = TestUtils.getProcessor(bridgeResponse.getId(), pr.getId()).as(ProcessorResponse.class);
 
         assertThat(found.getId()).isEqualTo(pr.getId());
-        assertThat(found.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(found.getAction().getType()).isEqualTo(KafkaTopicAction.TYPE);
         assertThat(found.getAction().getName()).isEqualTo(TestConstants.DEFAULT_ACTION_NAME);
         assertThat(found.getAction().getParameters()).containsEntry(KafkaTopicAction.TOPIC_PARAM, TestConstants.DEFAULT_KAFKA_TOPIC);
@@ -149,7 +148,6 @@ public class ProcessorAPITest {
         ProcessorResponse found = TestUtils.getProcessor(bridgeId, pr.getId()).as(ProcessorResponse.class);
 
         assertThat(found.getId()).isEqualTo(pr.getId());
-        assertThat(found.getBridgeId()).isEqualTo(bridgeId);
         assertThat(found.getAction().getType()).isEqualTo(SendToBridgeAction.TYPE);
         assertThat(found.getAction().getName()).isEqualTo(TestConstants.DEFAULT_ACTION_NAME);
         assertThat(found.getAction().getParameters()).containsEntry(SendToBridgeAction.BRIDGE_ID_PARAM, bridgeId);
@@ -199,12 +197,10 @@ public class ProcessorAPITest {
 
         ProcessorResponse processorResponse = response.as(ProcessorResponse.class);
         assertThat(processorResponse.getName()).isEqualTo("myProcessor");
-        assertThat(processorResponse.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(processorResponse.getFilters().size()).isEqualTo(1);
 
         ProcessorResponse retrieved = TestUtils.getProcessor(bridgeResponse.getId(), processorResponse.getId()).as(ProcessorResponse.class);
         assertThat(retrieved.getName()).isEqualTo("myProcessor");
-        assertThat(retrieved.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(retrieved.getFilters().size()).isEqualTo(1);
         assertThat(retrieved.getTransformationTemplate()).isEqualTo("{}");
         assertRequestedAction(retrieved);
@@ -269,7 +265,6 @@ public class ProcessorAPITest {
 
         ProcessorResponse processorResponse = response.as(ProcessorResponse.class);
         assertThat(processorResponse.getName()).isEqualTo("myProcessor");
-        assertThat(processorResponse.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(processorResponse.getFilters()).isNull();
         assertThat(processorResponse.getTransformationTemplate()).isNull();
         assertRequestedAction(processorResponse);
@@ -289,7 +284,6 @@ public class ProcessorAPITest {
 
         ProcessorResponse retrieved = TestUtils.getProcessor(bridgeResponse.getId(), response.as(ProcessorResponse.class).getId()).as(ProcessorResponse.class);
         assertThat(retrieved.getName()).isEqualTo("myProcessor");
-        assertThat(retrieved.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(retrieved.getFilters().size()).isEqualTo(1);
         assertThat(retrieved.getTransformationTemplate()).isNull();
         assertRequestedAction(retrieved);

--- a/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
+++ b/manager/src/test/java/com/redhat/service/bridge/manager/api/user/ProcessorAPITest.java
@@ -125,7 +125,7 @@ public class ProcessorAPITest {
         ProcessorResponse found = TestUtils.getProcessor(bridgeResponse.getId(), pr.getId()).as(ProcessorResponse.class);
 
         assertThat(found.getId()).isEqualTo(pr.getId());
-        assertThat(found.getBridge().getId()).isEqualTo(bridgeResponse.getId());
+        assertThat(found.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(found.getAction().getType()).isEqualTo(KafkaTopicAction.TYPE);
         assertThat(found.getAction().getName()).isEqualTo(TestConstants.DEFAULT_ACTION_NAME);
         assertThat(found.getAction().getParameters()).containsEntry(KafkaTopicAction.TOPIC_PARAM, TestConstants.DEFAULT_KAFKA_TOPIC);
@@ -149,7 +149,7 @@ public class ProcessorAPITest {
         ProcessorResponse found = TestUtils.getProcessor(bridgeId, pr.getId()).as(ProcessorResponse.class);
 
         assertThat(found.getId()).isEqualTo(pr.getId());
-        assertThat(found.getBridge().getId()).isEqualTo(bridgeId);
+        assertThat(found.getBridgeId()).isEqualTo(bridgeId);
         assertThat(found.getAction().getType()).isEqualTo(SendToBridgeAction.TYPE);
         assertThat(found.getAction().getName()).isEqualTo(TestConstants.DEFAULT_ACTION_NAME);
         assertThat(found.getAction().getParameters()).containsEntry(SendToBridgeAction.BRIDGE_ID_PARAM, bridgeId);
@@ -199,12 +199,12 @@ public class ProcessorAPITest {
 
         ProcessorResponse processorResponse = response.as(ProcessorResponse.class);
         assertThat(processorResponse.getName()).isEqualTo("myProcessor");
-        assertThat(processorResponse.getBridge().getId()).isEqualTo(bridgeResponse.getId());
+        assertThat(processorResponse.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(processorResponse.getFilters().size()).isEqualTo(1);
 
         ProcessorResponse retrieved = TestUtils.getProcessor(bridgeResponse.getId(), processorResponse.getId()).as(ProcessorResponse.class);
         assertThat(retrieved.getName()).isEqualTo("myProcessor");
-        assertThat(retrieved.getBridge().getId()).isEqualTo(bridgeResponse.getId());
+        assertThat(retrieved.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(retrieved.getFilters().size()).isEqualTo(1);
         assertThat(retrieved.getTransformationTemplate()).isEqualTo("{}");
         assertRequestedAction(retrieved);
@@ -269,7 +269,7 @@ public class ProcessorAPITest {
 
         ProcessorResponse processorResponse = response.as(ProcessorResponse.class);
         assertThat(processorResponse.getName()).isEqualTo("myProcessor");
-        assertThat(processorResponse.getBridge().getId()).isEqualTo(bridgeResponse.getId());
+        assertThat(processorResponse.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(processorResponse.getFilters()).isNull();
         assertThat(processorResponse.getTransformationTemplate()).isNull();
         assertRequestedAction(processorResponse);
@@ -289,7 +289,7 @@ public class ProcessorAPITest {
 
         ProcessorResponse retrieved = TestUtils.getProcessor(bridgeResponse.getId(), response.as(ProcessorResponse.class).getId()).as(ProcessorResponse.class);
         assertThat(retrieved.getName()).isEqualTo("myProcessor");
-        assertThat(retrieved.getBridge().getId()).isEqualTo(bridgeResponse.getId());
+        assertThat(retrieved.getBridgeId()).isEqualTo(bridgeResponse.getId());
         assertThat(retrieved.getFilters().size()).isEqualTo(1);
         assertThat(retrieved.getTransformationTemplate()).isNull();
         assertRequestedAction(retrieved);

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/BridgeExecutorServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/BridgeExecutorServiceImpl.java
@@ -53,7 +53,7 @@ public class BridgeExecutorServiceImpl implements BridgeExecutorService {
 
     @Override
     public void createBridgeExecutor(ProcessorDTO processorDTO) {
-        final Namespace namespace = customerNamespaceProvider.fetchOrCreateCustomerNamespace(processorDTO.getBridge().getCustomerId());
+        final Namespace namespace = customerNamespaceProvider.fetchOrCreateCustomerNamespace(processorDTO.getCustomerId());
 
         kubernetesClient
                 .resources(BridgeExecutor.class)
@@ -115,14 +115,14 @@ public class BridgeExecutorServiceImpl implements BridgeExecutorService {
 
     @Override
     public void deleteBridgeExecutor(ProcessorDTO processorDTO) {
-        final String namespace = customerNamespaceProvider.resolveName(processorDTO.getBridge().getCustomerId());
+        final String namespace = customerNamespaceProvider.resolveName(processorDTO.getCustomerId());
         final boolean bridgeDeleted =
                 kubernetesClient
                         .resources(BridgeExecutor.class)
                         .inNamespace(namespace)
                         .delete(BridgeExecutor.fromDTO(processorDTO, namespace, executorImage));
         if (bridgeDeleted) {
-            customerNamespaceProvider.deleteCustomerNamespaceIfEmpty(processorDTO.getBridge().getCustomerId());
+            customerNamespaceProvider.deleteCustomerNamespaceIfEmpty(processorDTO.getCustomerId());
         } else {
             // TODO: we might need to review this use case and have a manager to look at a queue of objects not deleted and investigate. Unfortunately the API does not give us a reason.
             LOGGER.warn("BridgeExecutor '{}' not deleted", processorDTO);

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/BridgeExecutor.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/BridgeExecutor.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.infra.models.processors.ProcessorDefinition;
 import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
@@ -49,8 +48,9 @@ public class BridgeExecutor extends CustomResource<BridgeExecutorSpec, BridgeExe
         return new Builder()
                 .withNamespace(namespace)
                 .withProcessorId(processorDTO.getId())
+                .withBridgeId(processorDTO.getBridgeId())
+                .withCustomerId(processorDTO.getCustomerId())
                 .withImageName(executorImage)
-                .withbridgeDTO(processorDTO.getBridge())
                 .withDefinition(processorDTO.getDefinition())
                 .withProcessorName(processorDTO.getName())
                 .build();
@@ -60,7 +60,8 @@ public class BridgeExecutor extends CustomResource<BridgeExecutorSpec, BridgeExe
         ProcessorDTO processorDTO = new ProcessorDTO();
         processorDTO.setId(this.getSpec().getId());
         // TODO: think about removing bridgeDTO from the processorDTO and keep only bridgeId and customerId!
-        processorDTO.setBridge(this.getSpec().getBridgeDTO());
+        processorDTO.setBridgeId(this.getSpec().getBridgeId());
+        processorDTO.setCustomerId(this.getSpec().getCustomerId());
         processorDTO.setName(this.getSpec().getProcessorName());
 
         if (this.getSpec().getProcessorDefinition() != null) {
@@ -83,7 +84,8 @@ public class BridgeExecutor extends CustomResource<BridgeExecutorSpec, BridgeExe
         private String namespace;
         private String imageName;
         private String processorId;
-        private BridgeDTO bridgeDTO;
+        private String bridgeId;
+        private String customerId;
         private String processorName;
         private ProcessorDefinition processorDefinition;
 
@@ -106,8 +108,13 @@ public class BridgeExecutor extends CustomResource<BridgeExecutorSpec, BridgeExe
             return this;
         }
 
-        public BridgeExecutor.Builder withbridgeDTO(final BridgeDTO bridgeDTO) {
-            this.bridgeDTO = bridgeDTO;
+        public BridgeExecutor.Builder withBridgeId(final String bridgeId) {
+            this.bridgeId = bridgeId;
+            return this;
+        }
+
+        public BridgeExecutor.Builder withCustomerId(final String customerId) {
+            this.customerId = customerId;
             return this;
         }
 
@@ -127,7 +134,7 @@ public class BridgeExecutor extends CustomResource<BridgeExecutorSpec, BridgeExe
                     .withName(resolveResourceName(this.processorId))
                     .withNamespace(namespace)
                     .withLabels(new LabelsBuilder()
-                            .withCustomerId(bridgeDTO.getCustomerId())
+                            .withCustomerId(customerId)
                             .withComponent(COMPONENT_NAME)
                             .buildWithDefaults())
                     .build();
@@ -135,7 +142,8 @@ public class BridgeExecutor extends CustomResource<BridgeExecutorSpec, BridgeExe
             BridgeExecutorSpec bridgeExecutorSpec = new BridgeExecutorSpec();
             bridgeExecutorSpec.setImage(imageName);
             bridgeExecutorSpec.setId(processorId);
-            bridgeExecutorSpec.setBridgeDTO(bridgeDTO);
+            bridgeExecutorSpec.setBridgeId(bridgeId);
+            bridgeExecutorSpec.setCustomerId(customerId);
             bridgeExecutorSpec.setProcessorName(processorName);
 
             try {
@@ -156,6 +164,8 @@ public class BridgeExecutor extends CustomResource<BridgeExecutorSpec, BridgeExe
             Objects.requireNonNull(Strings.emptyToNull(this.processorId), "[BridgeExecutor] Processor id can't be null");
             Objects.requireNonNull(Strings.emptyToNull(this.processorName), "[BridgeExecutor] Name can't be null");
             Objects.requireNonNull(Strings.emptyToNull(this.namespace), "[BridgeExecutor] Namespace can't be null");
+            Objects.requireNonNull(Strings.emptyToNull(this.customerId), "[BridgeExecutor] CustomerId can't be null");
+            Objects.requireNonNull(Strings.emptyToNull(this.bridgeId), "[BridgeExecutor] BridgeId can't be null");
             Objects.requireNonNull(this.processorDefinition, "[BridgeExecutor] Definition can't be null");
         }
     }

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/BridgeExecutorSpec.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/BridgeExecutorSpec.java
@@ -1,13 +1,13 @@
 package com.redhat.service.bridge.shard.operator.resources;
 
-import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
-
 public class BridgeExecutorSpec {
     private String image;
 
     private String id;
 
-    private BridgeDTO bridgeDTO;
+    private String bridgeId;
+
+    private String customerId;
 
     private String processorName;
 
@@ -29,12 +29,20 @@ public class BridgeExecutorSpec {
         this.id = id;
     }
 
-    public BridgeDTO getBridgeDTO() {
-        return bridgeDTO;
+    public String getBridgeId() {
+        return bridgeId;
     }
 
-    public void setBridgeDTO(BridgeDTO bridgeDTO) {
-        this.bridgeDTO = bridgeDTO;
+    public void setBridgeId(String bridgeId) {
+        this.bridgeId = bridgeId;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(String customerId) {
+        this.customerId = customerId;
     }
 
     public String getProcessorName() {

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/AbstractShardWireMockTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/AbstractShardWireMockTest.java
@@ -1,9 +1,6 @@
 package com.redhat.service.bridge.shard.operator;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -17,15 +14,9 @@ import org.junit.jupiter.api.BeforeEach;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.redhat.service.bridge.actions.kafkatopic.KafkaTopicAction;
 import com.redhat.service.bridge.infra.api.APIConstants;
-import com.redhat.service.bridge.infra.models.actions.BaseAction;
 import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
-import com.redhat.service.bridge.infra.models.dto.BridgeStatus;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
-import com.redhat.service.bridge.infra.models.filters.BaseFilter;
-import com.redhat.service.bridge.infra.models.filters.StringEquals;
-import com.redhat.service.bridge.infra.models.processors.ProcessorDefinition;
 import com.redhat.service.bridge.shard.operator.utils.KubernetesResourcePatcher;
 import com.redhat.service.bridge.test.wiremock.AbstractWireMockTest;
 
@@ -59,26 +50,6 @@ public abstract class AbstractShardWireMockTest extends AbstractWireMockTest {
     protected void beforeEach() {
         super.beforeEach();
         kubernetesResourcePatcher.cleanUp();
-    }
-
-    protected ProcessorDTO createProcessor(BridgeDTO bridge, BridgeStatus requestedStatus) {
-
-        Set<BaseFilter> filters = new HashSet<>();
-        filters.add(new StringEquals("key", "value"));
-
-        String transformationTemplate = "{\"test\": {key}}";
-
-        BaseAction a = new BaseAction();
-        a.setType(KafkaTopicAction.TYPE);
-        a.setName("kafkaAction");
-
-        Map<String, String> params = new HashMap<>();
-        params.put(KafkaTopicAction.TOPIC_PARAM, "myTopic");
-        a.setParameters(params);
-
-        ProcessorDefinition definition = new ProcessorDefinition(filters, transformationTemplate, a);
-
-        return new ProcessorDTO(TestSupport.PROCESSOR_ID, TestSupport.PROCESSOR_NAME, definition, bridge, requestedStatus);
     }
 
     protected void stubProcessorsToDeployOrDelete(List<ProcessorDTO> processorDTOS) throws JsonProcessingException {

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/BridgeExecutorServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/BridgeExecutorServiceTest.java
@@ -58,7 +58,7 @@ public class BridgeExecutorServiceTest {
         // Then
         BridgeExecutor bridgeExecutor = kubernetesClient
                 .resources(BridgeExecutor.class)
-                .inNamespace(customerNamespaceProvider.resolveName(dto.getBridge().getCustomerId()))
+                .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
                 .withName(BridgeExecutor.resolveResourceName(dto.getId()))
                 .get();
         assertThat(bridgeExecutor).isNotNull();
@@ -80,7 +80,7 @@ public class BridgeExecutorServiceTest {
                         () -> {
                             // The deployment is deployed by the controller
                             Deployment deployment = kubernetesClient.apps().deployments()
-                                    .inNamespace(customerNamespaceProvider.resolveName(dto.getBridge().getCustomerId()))
+                                    .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
                                     .withName(BridgeExecutor.resolveResourceName(dto.getId()))
                                     .get();
                             assertThat(deployment).isNotNull();
@@ -111,7 +111,7 @@ public class BridgeExecutorServiceTest {
         // Then
         BridgeIngress bridgeIngress = kubernetesClient
                 .resources(BridgeIngress.class)
-                .inNamespace(customerNamespaceProvider.resolveName(dto.getBridge().getCustomerId()))
+                .inNamespace(customerNamespaceProvider.resolveName(dto.getCustomerId()))
                 .withName(BridgeExecutor.resolveResourceName(dto.getId()))
                 .get();
         assertThat(bridgeIngress).isNull();

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/TestSupport.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/TestSupport.java
@@ -38,8 +38,6 @@ public class TestSupport {
     }
 
     public static ProcessorDTO newRequestedProcessorDTO() {
-        BridgeDTO bridgeDTO = newAvailableBridgeDTO();
-
         Set<BaseFilter> filters = new HashSet<>();
         filters.add(new StringEquals("key", "value"));
 
@@ -55,6 +53,6 @@ public class TestSupport {
 
         ProcessorDefinition definition = new ProcessorDefinition(filters, transformationTemplate, a);
 
-        return new ProcessorDTO(PROCESSOR_ID, PROCESSOR_NAME, definition, bridgeDTO, BridgeStatus.REQUESTED);
+        return new ProcessorDTO(PROCESSOR_ID, PROCESSOR_NAME, definition, BRIDGE_ID, CUSTOMER_ID, BridgeStatus.REQUESTED);
     }
 }

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/controllers/BridgeExecutorControllerTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/controllers/BridgeExecutorControllerTest.java
@@ -74,7 +74,8 @@ public class BridgeExecutorControllerTest {
                 .withImageName(TestSupport.EXECUTOR_IMAGE)
                 .withProcessorId(TestSupport.PROCESSOR_ID)
                 .withProcessorName(TestSupport.PROCESSOR_NAME)
-                .withbridgeDTO(TestSupport.newAvailableBridgeDTO())
+                .withBridgeId(TestSupport.BRIDGE_ID)
+                .withCustomerId(TestSupport.CUSTOMER_ID)
                 .withDefinition(new ProcessorDefinition())
                 .build();
     }

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderTest.java
@@ -33,7 +33,8 @@ public class TemplateProviderTest {
             .withProcessorName("id")
             .withNamespace("ns")
             .withImageName("image:latest")
-            .withbridgeDTO(TestSupport.newAvailableBridgeDTO())
+            .withBridgeId(TestSupport.BRIDGE_ID)
+            .withCustomerId(TestSupport.CUSTOMER_ID)
             .withProcessorId("id")
             .withDefinition(new ProcessorDefinition())
             .build();

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/resources/BridgeExecutorTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/resources/BridgeExecutorTest.java
@@ -20,6 +20,6 @@ public class BridgeExecutorTest {
         assertThat(bridgeExecutor.getSpec().getProcessorName()).isEqualTo(dto.getName());
         assertThat(bridgeExecutor.getSpec().getId()).isEqualTo(dto.getId());
         assertThat(bridgeExecutor.getSpec().getImage()).isEqualTo("image");
-        assertThat(bridgeExecutor.getSpec().getBridgeDTO().getId()).isEqualTo(TestSupport.BRIDGE_ID);
+        assertThat(bridgeExecutor.getSpec().getBridgeId()).isEqualTo(TestSupport.BRIDGE_ID);
     }
 }


### PR DESCRIPTION
[MGDOBR-39](https://issues.redhat.com/browse/MGDOBR-39) 

This PR removes the BridgeDTO from the ProcessorDTO. Only the `bridgeId` and the `customerId` is stored in the ProcessorDTO. The `BridgeResponse` is removed from the `ProcessorResponse` as well. 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
