### PR TITLE
MGDOBR-177: Store logs and events of Shard operator integration tests

### DIFF
--- a/.github/workflows/Operator-CI.yaml
+++ b/.github/workflows/Operator-CI.yaml
@@ -76,6 +76,12 @@ jobs:
         shell: bash
         working-directory: shard-operator-integration-tests
         run: mvn clean verify -Pcucumber
+      - name: Archive test logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: cucumber-logs
+          path: shard-operator-integration-tests/target/logs/**/*.*
       - name: Print operator log
         if: always()
         run: |

--- a/shard-operator-integration-tests/README.md
+++ b/shard-operator-integration-tests/README.md
@@ -13,6 +13,8 @@ Tests are implemented using [Cucumber-JVM](https://github.com/cucumber/cucumber-
 
 Every test scenario runs in a dedicated namespace which is deleted after the test execution. If user terminates test execution prematurely (CTRL + C) then namespace is not deleted automatically, needs to be deleted by user.
 
+Logs are stored in `target/logs` directory, contains logs of all containers and events in a namespace used to run the tests.
+
 ## Supported Maven parameters:
 - `tags`: Used to specify a single scenario to be executed. Set the parameter to (for example) `@wip` and annotate a scenario which you want to execute by same tag (`@wip`).
 - `parallel`: User to allow running tests in parallel.

--- a/shard-operator-integration-tests/pom.xml
+++ b/shard-operator-integration-tests/pom.xml
@@ -99,6 +99,7 @@
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                 <cucumber.filter.tags>${tags}</cucumber.filter.tags>
                 <cucumber.execution.parallel.enabled>${parallel}</cucumber.execution.parallel.enabled>
+                <test.logs>${project.build.directory}/logs</test.logs>
               </systemProperties>
             </configuration>
           </plugin>

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/Context.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/common/Context.java
@@ -1,5 +1,6 @@
 package com.redhat.service.bridge.shard.operator.cucumber.common;
 
+import io.cucumber.java.Scenario;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 
@@ -8,6 +9,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
  */
 public class Context {
 
+    private Scenario scenario;
     private String namespace;
     private OpenShiftClient oc;
 
@@ -22,5 +24,13 @@ public class Context {
 
     public OpenShiftClient getClient() {
         return oc;
+    }
+
+    public Scenario getScenario() {
+        return scenario;
+    }
+
+    public void setScenario(Scenario scenario) {
+        this.scenario = scenario;
     }
 }

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/logs/EventCollector.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/logs/EventCollector.java
@@ -1,0 +1,140 @@
+package com.redhat.service.bridge.shard.operator.cucumber.logs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Strings;
+
+import io.fabric8.kubernetes.api.model.events.v1.Event;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+/**
+ * Used to store events in a namespace.
+ */
+public class EventCollector {
+
+    private EventCollector() {
+    }
+
+    /**
+     * Store events in provided namespace
+     * 
+     * @param client
+     * @param logFolderName Name of a folder used to store logs
+     * @param namespace
+     * @throws IOException In case event log cannot be stored on filesystem for any reason
+     */
+    public static void storeNamespaceEvents(OpenShiftClient client, String logFolderName, String namespace) throws IOException {
+        Path logParentDirectory = LogConfig.getLogParentDirectory(logFolderName);
+        Files.createDirectories(logParentDirectory);
+
+        List<Event> events = client.events().v1().events().inNamespace(namespace).list().getItems();
+        List<Map<EventEntry, String>> eventContent = new ArrayList<>();
+        Map<EventEntry, String> eventHeader = new HashMap<>();
+        eventHeader.put(EventEntry.LAST_SEEN, EventEntry.LAST_SEEN.toString());
+        eventHeader.put(EventEntry.FIRST_SEEN, EventEntry.FIRST_SEEN.toString());
+        eventHeader.put(EventEntry.COUNT, EventEntry.COUNT.toString());
+        eventHeader.put(EventEntry.NAME, EventEntry.NAME.toString());
+        eventHeader.put(EventEntry.KIND, EventEntry.KIND.toString());
+        eventHeader.put(EventEntry.SUBOBJECT, EventEntry.SUBOBJECT.toString());
+        eventHeader.put(EventEntry.TYPE, EventEntry.TYPE.toString());
+        eventHeader.put(EventEntry.REASON, EventEntry.REASON.toString());
+        eventHeader.put(EventEntry.ACTION, EventEntry.ACTION.toString());
+        eventHeader.put(EventEntry.MESSAGE, EventEntry.MESSAGE.toString());
+        eventContent.add(eventHeader);
+
+        for (Event event : events) {
+            Map<EventEntry, String> eventEntry = new HashMap<>();
+            eventEntry.put(EventEntry.LAST_SEEN, getLastSeen(event));
+            eventEntry.put(EventEntry.FIRST_SEEN, getFirstSeen(event));
+            eventEntry.put(EventEntry.COUNT, event.getSeries() != null ? event.getSeries().getCount().toString() : "1");
+            eventEntry.put(EventEntry.NAME, event.getRegarding().getName());
+            eventEntry.put(EventEntry.KIND, event.getRegarding().getKind());
+            eventEntry.put(EventEntry.SUBOBJECT, event.getRegarding().getFieldPath());
+            eventEntry.put(EventEntry.TYPE, event.getType());
+            eventEntry.put(EventEntry.REASON, event.getReason());
+            eventEntry.put(EventEntry.ACTION, event.getAction());
+            eventEntry.put(EventEntry.MESSAGE, event.getNote());
+            eventContent.add(eventEntry);
+        }
+        for (Map<EventEntry, String> eventEntry : eventContent) {
+            Files.write(logParentDirectory.resolve(Paths.get("events.log")),
+                    getEventLogLine(eventEntry).getBytes(),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND,
+                    StandardOpenOption.WRITE);
+        }
+    }
+
+    /**
+     * @param event
+     * @return Timestamp of the last event observation
+     */
+    private static String getLastSeen(Event event) {
+        if (event.getSeries() != null && event.getSeries().getLastObservedTime() != null) {
+            return event.getSeries().getLastObservedTime().getTime();
+        }
+        if (event.getEventTime() != null) {
+            return event.getEventTime().getTime();
+        }
+        // Using deprecated values if new ones are not available - https://kubernetes.io/docs/reference/_print/#event-v125
+        if (!Strings.isNullOrEmpty(event.getDeprecatedLastTimestamp())) {
+            return event.getDeprecatedLastTimestamp();
+        }
+        return "N/A";
+    }
+
+    /**
+     * @param event
+     * @return Timestamp of the first event observation
+     */
+    private static String getFirstSeen(Event event) {
+        if (event.getEventTime() != null) {
+            return event.getEventTime().getTime();
+        }
+        // Using deprecated values if new ones are not available - https://kubernetes.io/docs/reference/_print/#event-v125
+        if (!Strings.isNullOrEmpty(event.getDeprecatedFirstTimestamp())) {
+            return event.getDeprecatedFirstTimestamp();
+        }
+        return "N/A";
+    }
+
+    /**
+     * @param eventEntry
+     * @return Event log line printing event entry in defined format
+     */
+    private static String getEventLogLine(Map<EventEntry, String> eventEntry) {
+        StringBuilder eventLogLine = new StringBuilder();
+        eventLogLine.append(String.format("%27s |", eventEntry.get(EventEntry.LAST_SEEN)));
+        eventLogLine.append(String.format(" %27s |", eventEntry.get(EventEntry.FIRST_SEEN)));
+        eventLogLine.append(String.format(" %5s |", eventEntry.get(EventEntry.COUNT)));
+        eventLogLine.append(String.format(" %40s |", eventEntry.get(EventEntry.NAME)));
+        eventLogLine.append(String.format(" %20s |", eventEntry.get(EventEntry.KIND)));
+        eventLogLine.append(String.format(" %30s |", eventEntry.get(EventEntry.SUBOBJECT)));
+        eventLogLine.append(String.format(" %10s |", eventEntry.get(EventEntry.TYPE)));
+        eventLogLine.append(String.format(" %25s |", eventEntry.get(EventEntry.REASON)));
+        eventLogLine.append(String.format(" %10s |", eventEntry.get(EventEntry.ACTION)));
+        eventLogLine.append(String.format(" %s\n", eventEntry.get(EventEntry.MESSAGE)));
+        return eventLogLine.toString();
+    }
+
+    private enum EventEntry {
+        LAST_SEEN,
+        FIRST_SEEN,
+        COUNT,
+        NAME,
+        KIND,
+        SUBOBJECT,
+        TYPE,
+        REASON,
+        ACTION,
+        MESSAGE;
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/logs/LogCollector.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/logs/LogCollector.java
@@ -1,0 +1,61 @@
+package com.redhat.service.bridge.shard.operator.cucumber.logs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.google.common.base.Strings;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+/**
+ * Used to store pod logs in a namespace.
+ */
+public class LogCollector {
+
+    private LogCollector() {
+    }
+
+    /**
+     * Store logs of all pods in provided namespace
+     * 
+     * @param client
+     * @param logFolderName Name of a folder used to store logs
+     * @param namespace
+     * @throws IOException In case log cannot be stored on filesystem for any reason
+     */
+    public static void storeNamespacePodLogs(OpenShiftClient client, String logFolderName, String namespace) throws IOException {
+        Path logParentDirectory = LogConfig.getLogParentDirectory(logFolderName);
+        Files.createDirectories(logParentDirectory);
+
+        for (Pod pod : client.pods().inNamespace(namespace).list().getItems()) {
+            for (Container container : pod.getSpec().getContainers()) {
+                String log = "";
+                if (Strings.isNullOrEmpty(container.getName())) {
+                    // Retrieve default pod log if container name is not specified
+                    log = client.pods().inNamespace(namespace).withName(pod.getMetadata().getName()).getLog();
+                } else {
+                    log = client.pods().inNamespace(namespace).withName(pod.getMetadata().getName()).inContainer(container.getName()).getLog();
+                }
+                Files.write(getLogFilePath(logParentDirectory, pod, container), log.getBytes());
+            }
+        }
+    }
+
+    /**
+     * @param logParentDirectory Path to a folder used to store logs
+     * @param pod
+     * @param container
+     * @return Path pointing to the log file, name containing pod name and optionally container name
+     */
+    private static Path getLogFilePath(Path logParentDirectory, Pod pod, Container container) {
+        String logFileName = String.format("%s.log", pod.getMetadata().getName());
+        if (!Strings.isNullOrEmpty(container.getName())) {
+            logFileName = String.format("%s-%s.log", pod.getMetadata().getName(), container.getName());
+        }
+        return logParentDirectory.resolve(Paths.get(logFileName));
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/logs/LogConfig.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/logs/LogConfig.java
@@ -1,0 +1,16 @@
+package com.redhat.service.bridge.shard.operator.cucumber.logs;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class LogConfig {
+
+    private static String logsOutputDirectory = System.getProperty("test.logs", "logs");
+
+    private LogConfig() {
+    }
+
+    public static Path getLogParentDirectory(String logFolderName) {
+        return Paths.get(logsOutputDirectory, logFolderName);
+    }
+}

--- a/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/Hooks.java
+++ b/shard-operator-integration-tests/src/test/java/com/redhat/service/bridge/shard/operator/cucumber/steps/Hooks.java
@@ -1,10 +1,14 @@
 package com.redhat.service.bridge.shard.operator.cucumber.steps;
 
-import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import com.redhat.service.bridge.shard.operator.cucumber.common.Context;
+import com.redhat.service.bridge.shard.operator.cucumber.logs.EventCollector;
+import com.redhat.service.bridge.shard.operator.cucumber.logs.LogCollector;
 
 import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
 
 /**
  * Cucumber hooks for setup and cleanup
@@ -17,8 +21,19 @@ public class Hooks {
         this.context = context;
     }
 
-    @After
-    public void cleanupNamespaceAfterScenario() throws FileNotFoundException {
+    @Before
+    public void before(Scenario scenario) {
+        this.context.setScenario(scenario);
+    }
+
+    @After(order = 10)
+    public void cleanupTestNamespaceAfterScenario() {
         context.getClient().namespaces().withName(context.getNamespace()).delete();
+    }
+
+    @After(order = 20)
+    public void storeTestNamespaceLogs() throws IOException {
+        LogCollector.storeNamespacePodLogs(context.getClient(), String.format("%s-%s", context.getScenario().getName(), context.getNamespace()), context.getNamespace());
+        EventCollector.storeNamespaceEvents(context.getClient(), String.format("%s-%s", context.getScenario().getName(), context.getNamespace()), context.getNamespace());
     }
 }


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

[MGDOBR-177](https://issues.redhat.com/browse/MGDOBR-177) 

Integration test logs are stored in `target/logs` directory. Namespace events are stored too.

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
