### PR TITLE
[MGDOBR-95] Add ServiceMonitor to BridgeIngress

### DIFF
--- a/.github/workflows/Operator-CI.yaml
+++ b/.github/workflows/Operator-CI.yaml
@@ -72,6 +72,8 @@ jobs:
           # Point SSO URL to the Keycloak Service port, use HTTP to avoid complications with certificate
           kubectl set env deployment/shard-operator EVENT_BRIDGE_SSO_URL=http://keycloak:8180/auth/realms/event-bridge-fm -n $NAMESPACE
           kubectl wait --for=condition=available --timeout=120s deployment/shard-operator -n $NAMESPACE
+          # Add Prometheus ServiceMonitor CRD to avoid BridgeIngress Condition Ready: False Type: PrometheusUnavailable
+          kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.9.0/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
       - name: Run integration tests
         shell: bash
         working-directory: shard-operator-integration-tests

--- a/ingress/pom.xml
+++ b/ingress/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
     <dependency>

--- a/ingress/pom.xml
+++ b/ingress/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-metrics</artifactId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/kustomize/base/shard/resources/bridgeexecutors.com.redhat.service.bridge-v1.yml
+++ b/kustomize/base/shard/resources/bridgeexecutors.com.redhat.service.bridge-v1.yml
@@ -49,6 +49,7 @@ spec:
                       - DeploymentNotAvailable
                       - DeploymentFailed
                       - ServiceNotReady
+                      - PrometheusUnavailable
                       - DeploymentAvailable
                       - DeploymentProgressing
                       - NetworkResourceNotReady

--- a/kustomize/base/shard/resources/bridgeingresses.com.redhat.service.bridge-v1.yml
+++ b/kustomize/base/shard/resources/bridgeingresses.com.redhat.service.bridge-v1.yml
@@ -47,6 +47,7 @@ spec:
                       - DeploymentNotAvailable
                       - DeploymentFailed
                       - ServiceNotReady
+                      - PrometheusUnavailable
                       - DeploymentAvailable
                       - DeploymentProgressing
                       - NetworkResourceNotReady

--- a/shard-operator/pom.xml
+++ b/shard-operator/pom.xml
@@ -55,7 +55,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-oidc-client</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-model-monitoring</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.redhat.service.bridge</groupId>
       <artifactId>test-utils</artifactId>

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/BridgeIngressServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/BridgeIngressServiceImpl.java
@@ -1,6 +1,7 @@
 package com.redhat.service.bridge.shard.operator;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -98,6 +99,11 @@ public class BridgeIngressServiceImpl implements BridgeIngressService {
 
         // Specs
         service.getSpec().setSelector(new LabelsBuilder().withAppInstance(deployment.getMetadata().getName()).build());
+        // The service must have a label to link with a supposed ServiceMonitor: https://prometheus-operator.dev/docs/operator/troubleshooting/#overview-of-servicemonitor-tagging-and-related-elements
+        if (service.getMetadata().getLabels() == null) {
+            service.getMetadata().setLabels(new HashMap<>());
+        }
+        service.getMetadata().getLabels().putAll(new LabelsBuilder().withAppInstance(deployment.getMetadata().getName()).buildWithDefaults());
 
         return kubernetesClient.services().inNamespace(bridgeIngress.getMetadata().getNamespace()).create(service);
     }

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressController.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressController.java
@@ -111,10 +111,15 @@ public class BridgeIngressController implements ResourceController<BridgeIngress
         }
         LOGGER.debug("Ingress networking resource BridgeIngress: '{}' in namespace '{}' is ready", bridgeIngress.getMetadata().getName(), bridgeIngress.getMetadata().getNamespace());
 
+        // TODO: on https://issues.redhat.com/browse/MGDOBR-163 we will make this piece a common algorithm between our controllers
         Optional<ServiceMonitor> serviceMonitor = monitorService.fetchOrCreateServiceMonitor(bridgeIngress, service);
         if (serviceMonitor.isPresent()) {
             // this is an optional resource
             LOGGER.debug("Ingress monitor resource BridgeIngress: '{}' in namespace '{}' is ready", bridgeIngress.getMetadata().getName(), bridgeIngress.getMetadata().getNamespace());
+        } else {
+            // TODO: the message will be a constant on MGDOBR-163
+            bridgeIngress.getStatus().markConditionFalse(ConditionType.Ready, ConditionReason.PrometheusUnavailable, "ServiceMonitor CRD not available");
+            return UpdateControl.updateStatusSubResource(bridgeIngress);
         }
 
         if (!bridgeIngress.getStatus().isReady() || !networkResource.getEndpoint().equals(bridgeIngress.getStatus().getEndpoint())) {

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorClient.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorClient.java
@@ -1,0 +1,28 @@
+package com.redhat.service.bridge.shard.operator.monitoring;
+
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
+
+/**
+ * Collection of shortcuts to interact with the Prometheus ServiceMonitor Resource
+ */
+public final class ServiceMonitorClient {
+
+    public static final String SERVICE_MONITOR_CRD_NAME = "servicemonitors.monitoring.coreos.com";
+
+    private ServiceMonitorClient() {
+    }
+
+    public static MixedOperation<ServiceMonitor, KubernetesResourceList<ServiceMonitor>, Resource<ServiceMonitor>> get(final KubernetesClient kubernetesClient) {
+        return kubernetesClient.resources(ServiceMonitor.class);
+    }
+
+    public static boolean isServiceMonitorAvailable(final KubernetesClient kubernetesClient) {
+        final CustomResourceDefinition serviceMonitorCRD = kubernetesClient.apiextensions().v1().customResourceDefinitions().withName(SERVICE_MONITOR_CRD_NAME).get();
+        return serviceMonitorCRD != null;
+    }
+}

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorService.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorService.java
@@ -1,0 +1,22 @@
+package com.redhat.service.bridge.shard.operator.monitoring;
+
+import java.util.Optional;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
+
+/**
+ * Service to handle the Prometheus extension resources.
+ */
+public interface ServiceMonitorService {
+
+    /**
+     * Fetch or create a new {@link ServiceMonitor} Prometheus Operator instance.
+     *
+     * @param service the target Kubernetes {@link Service} to bind the monitoring resource.
+     * @param resource the custom resource managed by this operator (e.g. BridgeIngress).
+     * @return an {@link Optional} {@link ServiceMonitor} if Prometheus Operator is installed in the cluster.
+     */
+    Optional<ServiceMonitor> fetchOrCreateServiceMonitor(final CustomResource resource, final Service service);
+}

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceImpl.java
@@ -1,0 +1,53 @@
+package com.redhat.service.bridge.shard.operator.monitoring;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.redhat.service.bridge.shard.operator.providers.TemplateProvider;
+import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
+
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
+
+@ApplicationScoped
+public class ServiceMonitorServiceImpl implements ServiceMonitorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceMonitorServiceImpl.class);
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    TemplateProvider templateProvider;
+
+    @Override
+    public Optional<ServiceMonitor> fetchOrCreateServiceMonitor(final CustomResource resource, final Service service) {
+        if (!ServiceMonitorClient.isServiceMonitorAvailable(kubernetesClient)) {
+            LOGGER.debug("Prometheus Operator is not available in this cluster");
+            return Optional.empty();
+        }
+        ServiceMonitor serviceMonitor = ServiceMonitorClient
+                .get(kubernetesClient)
+                .inNamespace(resource.getMetadata().getNamespace())
+                .withName(service.getMetadata().getName())
+                .get();
+        if (serviceMonitor == null) {
+            LOGGER.debug("Prometheus ServiceMonitor does not exist. Creating a new instance.");
+            serviceMonitor = templateProvider.loadServiceMonitorTemplate(resource);
+        }
+        // enforce the labels
+        if (serviceMonitor.getSpec().getSelector() == null) {
+            serviceMonitor.getSpec().setSelector(new LabelSelector());
+        }
+        serviceMonitor.getSpec().getSelector().setMatchLabels(new LabelsBuilder().withAppInstance(service.getMetadata().getName()).build());
+        return Optional.of(serviceMonitor);
+    }
+}

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/providers/TemplateProvider.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/providers/TemplateProvider.java
@@ -6,7 +6,9 @@ import com.redhat.service.bridge.shard.operator.resources.BridgeIngress;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
 
 public interface TemplateProvider {
 
@@ -21,4 +23,6 @@ public interface TemplateProvider {
     Route loadBridgeIngressOpenshiftRouteTemplate(BridgeIngress bridgeIngress);
 
     Ingress loadBridgeIngressKubernetesIngressTemplate(BridgeIngress bridgeIngress);
+
+    ServiceMonitor loadServiceMonitorTemplate(CustomResource resource);
 }

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderImpl.java
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
 
 @ApplicationScoped
 public class TemplateProviderImpl implements TemplateProvider {
@@ -26,6 +27,7 @@ public class TemplateProviderImpl implements TemplateProvider {
     private static final String BRIDGE_EXECUTOR_SERVICE_PATH = TEMPLATES_DIR + "/bridge-executor-service.yaml";
     private static final String BRIDGE_INGRESS_OPENSHIFT_ROUTE_PATH = TEMPLATES_DIR + "/bridge-ingress-openshift-route.yaml";
     private static final String BRIDGE_INGRESS_KUBERNETES_INGRESS_PATH = TEMPLATES_DIR + "/bridge-ingress-kubernetes-ingress.yaml";
+    private static final String SERVICE_MONITOR_PATH = TEMPLATES_DIR + "/service-monitor.yaml";
 
     @Override
     public Deployment loadBridgeIngressDeploymentTemplate(BridgeIngress bridgeIngress) {
@@ -67,6 +69,13 @@ public class TemplateProviderImpl implements TemplateProvider {
         Ingress ingress = loadYaml(Ingress.class, BRIDGE_INGRESS_KUBERNETES_INGRESS_PATH);
         updateMetadata(bridgeIngress, ingress.getMetadata());
         return ingress;
+    }
+
+    @Override
+    public ServiceMonitor loadServiceMonitorTemplate(CustomResource resource) {
+        final ServiceMonitor serviceMonitor = loadYaml(ServiceMonitor.class, SERVICE_MONITOR_PATH);
+        updateMetadata(resource, serviceMonitor.getMetadata());
+        return serviceMonitor;
     }
 
     private <T> T loadYaml(Class<T> clazz, String yaml) {

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/ConditionReason.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/ConditionReason.java
@@ -16,5 +16,6 @@ public enum ConditionReason {
     DeploymentFailed,
     DeploymentNotAvailable,
     ServiceNotReady,
-    NetworkResourceNotReady;
+    NetworkResourceNotReady,
+    PrometheusUnavailable;
 }

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/BaseEventSource.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/BaseEventSource.java
@@ -1,0 +1,77 @@
+package com.redhat.service.bridge.shard.operator.watchers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.WatcherException;
+import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
+import io.javaoperatorsdk.operator.processing.event.DefaultEvent;
+import io.quarkus.runtime.Quarkus;
+
+import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
+import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getVersion;
+
+public abstract class BaseEventSource<R extends HasMetadata, E extends DefaultEvent> extends AbstractEventSource implements Watcher<R> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeploymentEventSource.class);
+
+    private final String component;
+
+    public BaseEventSource(final String component) {
+        this.component = component;
+    }
+
+    protected abstract E newEvent(Watcher.Action action, R resource);
+
+    protected abstract void registerWatch(String component);
+
+    @Override
+    public void eventReceived(Action action, R resource) {
+        if (eventHandler == null) {
+            LOGGER.warn("Ignoring action '{}' for resource '{}'. EventHandler has not yet been initialized.", resource.getKind(), action);
+            return;
+        }
+
+        LOGGER.info(
+                "Event received for action: '{}', '{}': '{}'",
+                action.name(),
+                resource.getKind(),
+                resource.getMetadata().getName());
+
+        if (action == Action.ERROR) {
+            LOGGER.warn(
+                    "Skipping '{}' event for custom resource uid: '{}', version: '{}'",
+                    action,
+                    getUID(resource),
+                    getVersion(resource));
+            return;
+        }
+
+        if (resource.getMetadata().getOwnerReferences().isEmpty()) {
+            LOGGER.warn("Unable to retrieve Owner UID. Ignoring event {} {}/{}", resource.getMetadata().getNamespace(),
+                    resource.getKind(), resource.getMetadata().getName());
+            return;
+        }
+
+        eventHandler.handleEvent(this.newEvent(action, resource));
+    }
+
+    @Override
+    public void onClose(WatcherException e) {
+        if (e == null) {
+            LOGGER.warn("Unknown error happened with watch.");
+            return;
+        }
+        if (e.isHttpGone()) {
+            LOGGER.warn("Received error for watch, will try to reconnect.", e);
+            registerWatch(this.component);
+        } else {
+            // Note that this should not happen normally, since fabric8 client handles reconnect.
+            // In case it tries to reconnect this method is not called.
+            LOGGER.error("Unexpected error happened with watch. Will exit.", e);
+            Quarkus.asyncExit(1);
+        }
+    }
+}

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/DeploymentEventSource.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/DeploymentEventSource.java
@@ -1,30 +1,16 @@
 package com.redhat.service.bridge.shard.operator.watchers;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.WatcherException;
-import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
-import io.quarkus.runtime.Quarkus;
-
-import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
-import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getVersion;
 
 /**
  * Used by the controllers to watch changes on Deployment objects.
- *
  */
-public class DeploymentEventSource extends AbstractEventSource implements Watcher<Deployment> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeploymentEventSource.class);
+public class DeploymentEventSource extends BaseEventSource<Deployment, DeploymentEvent> {
 
     private final KubernetesClient client;
-
-    private final String component;
 
     public static DeploymentEventSource createAndRegisterWatch(KubernetesClient client, String component) {
         DeploymentEventSource deploymentEventSource = new DeploymentEventSource(client, component);
@@ -33,11 +19,17 @@ public class DeploymentEventSource extends AbstractEventSource implements Watche
     }
 
     private DeploymentEventSource(KubernetesClient client, String component) {
+        super(component);
         this.client = client;
-        this.component = component;
     }
 
-    private void registerWatch(String component) {
+    @Override
+    protected DeploymentEvent newEvent(Action action, Deployment resource) {
+        return new DeploymentEvent(action, resource, this);
+    }
+
+    @Override
+    protected void registerWatch(String component) {
         client
                 .apps()
                 .deployments()
@@ -48,41 +40,5 @@ public class DeploymentEventSource extends AbstractEventSource implements Watche
                                 .withComponent(component)
                                 .build())
                 .watch(this);
-    }
-
-    @Override
-    public void eventReceived(Action action, Deployment deployment) {
-        LOGGER.info(
-                "Event received for action: '{}', Deployment: '{}'",
-                action.name(),
-                deployment.getMetadata().getName());
-
-        if (action == Action.ERROR) {
-            LOGGER.warn(
-                    "Skipping '{}' event for custom resource uid: '{}', version: '{}'",
-                    action,
-                    getUID(deployment),
-                    getVersion(deployment));
-            return;
-        }
-
-        eventHandler.handleEvent(new DeploymentEvent(action, deployment, this));
-    }
-
-    @Override
-    public void onClose(WatcherException e) {
-        if (e == null) {
-            LOGGER.warn("Unknown error happened with watch.");
-            return;
-        }
-        if (e.isHttpGone()) {
-            LOGGER.warn("Received error for watch, will try to reconnect.", e);
-            registerWatch(this.component);
-        } else {
-            // Note that this should not happen normally, since fabric8 client handles reconnect.
-            // In case it tries to reconnect this method is not called.
-            LOGGER.error("Unexpected error happened with watch. Will exit.", e);
-            Quarkus.asyncExit(1);
-        }
     }
 }

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/ServiceEventSource.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/ServiceEventSource.java
@@ -1,26 +1,13 @@
 package com.redhat.service.bridge.shard.operator.watchers;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.WatcherException;
-import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
-import io.quarkus.runtime.Quarkus;
 
-import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getUID;
-import static io.javaoperatorsdk.operator.processing.KubernetesResourceUtils.getVersion;
-
-public class ServiceEventSource extends AbstractEventSource implements Watcher<Service> {
-    private static final Logger log = LoggerFactory.getLogger(ServiceEventSource.class);
+public class ServiceEventSource extends BaseEventSource<Service, ServiceEvent> {
 
     private final KubernetesClient client;
-
-    private final String component;
 
     public static ServiceEventSource createAndRegisterWatch(KubernetesClient client, String component) {
         ServiceEventSource serviceEventSource = new ServiceEventSource(client, component);
@@ -29,11 +16,17 @@ public class ServiceEventSource extends AbstractEventSource implements Watcher<S
     }
 
     private ServiceEventSource(KubernetesClient client, String component) {
+        super(component);
         this.client = client;
-        this.component = component;
     }
 
-    private void registerWatch(String component) {
+    @Override
+    protected ServiceEvent newEvent(Action action, Service resource) {
+        return new ServiceEvent(action, resource, this);
+    }
+
+    @Override
+    protected void registerWatch(String component) {
         client
                 .services()
                 .inAnyNamespace()
@@ -43,41 +36,5 @@ public class ServiceEventSource extends AbstractEventSource implements Watcher<S
                                 .withComponent(component)
                                 .build())
                 .watch(this);
-    }
-
-    @Override
-    public void eventReceived(Watcher.Action action, Service service) {
-        log.info(
-                "Event received for action: {}, Service: {}",
-                action.name(),
-                service.getMetadata().getName());
-
-        if (action == Watcher.Action.ERROR) {
-            log.warn(
-                    "Skipping {} event for custom resource uid: {}, version: {}",
-                    action,
-                    getUID(service),
-                    getVersion(service));
-            return;
-        }
-
-        eventHandler.handleEvent(new ServiceEvent(action, service, this));
-    }
-
-    @Override
-    public void onClose(WatcherException e) {
-        if (e == null) {
-            log.warn("Unknown error happened with watch.");
-            return;
-        }
-        if (e.isHttpGone()) {
-            log.warn("Received error for watch, will try to reconnect.", e);
-            registerWatch(this.component);
-        } else {
-            // Note that this should not happen normally, since fabric8 client handles reconnect.
-            // In case it tries to reconnect this method is not called.
-            log.error("Unexpected error happened with watch. Will exit.", e);
-            Quarkus.asyncExit(1);
-        }
     }
 }

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/monitoring/ServiceMonitorEvent.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/monitoring/ServiceMonitorEvent.java
@@ -1,0 +1,49 @@
+package com.redhat.service.bridge.shard.operator.watchers.monitoring;
+
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
+import io.javaoperatorsdk.operator.processing.event.DefaultEvent;
+
+public class ServiceMonitorEvent extends DefaultEvent {
+
+    private final Watcher.Action action;
+    private final ServiceMonitor serviceMonitor;
+
+    public ServiceMonitorEvent(Watcher.Action action, ServiceMonitor resource, ServiceMonitorEventSource serviceMonitorEventSource) {
+        super(resource.getMetadata().getOwnerReferences().get(0).getUid(), serviceMonitorEventSource);
+        this.action = action;
+        this.serviceMonitor = resource;
+    }
+
+    public Watcher.Action getAction() {
+        return action;
+    }
+
+    public String resourceUid() {
+        return serviceMonitor.getMetadata().getUid();
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceMonitorEvent{"
+                + "action="
+                + action
+                + ", resource=[ name="
+                + getServiceMonitor().getMetadata().getName()
+                + ", kind="
+                + getServiceMonitor().getKind()
+                + ", apiVersion="
+                + getServiceMonitor().getApiVersion()
+                + " ,resourceVersion="
+                + getServiceMonitor().getMetadata().getResourceVersion()
+                + ", markedForDeletion: "
+                + (getServiceMonitor().getMetadata().getDeletionTimestamp() != null
+                        && !getServiceMonitor().getMetadata().getDeletionTimestamp().isEmpty())
+                + " ]"
+                + '}';
+    }
+
+    public ServiceMonitor getServiceMonitor() {
+        return serviceMonitor;
+    }
+}

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/monitoring/ServiceMonitorEventSource.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/monitoring/ServiceMonitorEventSource.java
@@ -1,0 +1,45 @@
+package com.redhat.service.bridge.shard.operator.watchers.monitoring;
+
+import java.util.Optional;
+
+import com.redhat.service.bridge.shard.operator.monitoring.ServiceMonitorClient;
+import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
+import com.redhat.service.bridge.shard.operator.watchers.BaseEventSource;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
+
+public class ServiceMonitorEventSource extends BaseEventSource<ServiceMonitor, ServiceMonitorEvent> {
+
+    private final KubernetesClient client;
+
+    public static Optional<ServiceMonitorEventSource> createAndRegisterWatch(KubernetesClient client, String component) {
+        if (ServiceMonitorClient.isServiceMonitorAvailable(client)) {
+            final ServiceMonitorEventSource serviceMonitorEventSource = new ServiceMonitorEventSource(client, component);
+            serviceMonitorEventSource.registerWatch(component);
+            return Optional.of(serviceMonitorEventSource);
+        }
+        return Optional.empty();
+    }
+
+    private ServiceMonitorEventSource(KubernetesClient client, String component) {
+        super(component);
+        this.client = client;
+    }
+
+    @Override
+    protected ServiceMonitorEvent newEvent(Action action, ServiceMonitor resource) {
+        return new ServiceMonitorEvent(action, resource, this);
+    }
+
+    @Override
+    protected void registerWatch(String component) {
+        ServiceMonitorClient.get(client)
+                .inAnyNamespace()
+                .withLabels(new LabelsBuilder()
+                        .withManagedByOperator()
+                        .withComponent(component)
+                        .build())
+                .watch(this);
+    }
+}

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/networking/OpenshiftRouteEventSource.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/watchers/networking/OpenshiftRouteEventSource.java
@@ -1,24 +1,14 @@
 package com.redhat.service.bridge.shard.operator.watchers.networking;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.redhat.service.bridge.shard.operator.utils.LabelsBuilder;
+import com.redhat.service.bridge.shard.operator.watchers.BaseEventSource;
 
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.WatcherException;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
-import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
-import io.quarkus.runtime.Quarkus;
 
-public class OpenshiftRouteEventSource extends AbstractEventSource implements Watcher<Route> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenshiftRouteEventSource.class);
+public class OpenshiftRouteEventSource extends BaseEventSource<Route, NetworkResourceEvent> {
 
     private final OpenShiftClient client;
-
-    private final String component;
 
     public static OpenshiftRouteEventSource createAndRegisterWatch(OpenShiftClient client, String component) {
         OpenshiftRouteEventSource eventSource = new OpenshiftRouteEventSource(client, component);
@@ -27,11 +17,16 @@ public class OpenshiftRouteEventSource extends AbstractEventSource implements Wa
     }
 
     private OpenshiftRouteEventSource(OpenShiftClient client, String component) {
+        super(component);
         this.client = client;
-        this.component = component;
     }
 
-    private void registerWatch(String component) {
+    @Override
+    protected NetworkResourceEvent newEvent(Action action, Route resource) {
+        return new NetworkResourceEvent(action, resource.getMetadata().getOwnerReferences().get(0), this);
+    }
+
+    protected void registerWatch(String component) {
         client.routes().inAnyNamespace()
                 .withLabels(
                         new LabelsBuilder()
@@ -39,54 +34,5 @@ public class OpenshiftRouteEventSource extends AbstractEventSource implements Wa
                                 .withComponent(component)
                                 .build())
                 .watch(this);
-    }
-
-    @Override
-    public void eventReceived(Action action, Route route) {
-        if (eventHandler == null) {
-            LOGGER.warn("Ignoring action {} for resource Route. EventHandler has not yet been initialized.", action);
-            return;
-        }
-
-        LOGGER.info(
-                "Event received for action: {}, {}: {}",
-                action.name(),
-                "Route",
-                route.getMetadata().getName());
-
-        if (action == Action.ERROR) {
-            LOGGER.warn(
-                    "Skipping {} event for {} uid: {}, version: {}",
-                    action,
-                    "Route",
-                    route.getMetadata().getUid(),
-                    route.getMetadata().getResourceVersion());
-            return;
-        }
-
-        if (route.getMetadata().getOwnerReferences().isEmpty()) {
-            LOGGER.warn("Unable to retrieve Owner UID. Ignoring event {} {}/{}", route.getMetadata().getNamespace(),
-                    route.getKind(), route.getMetadata().getName());
-            return;
-        }
-
-        eventHandler.handleEvent(new NetworkResourceEvent(action, route.getMetadata().getOwnerReferences().get(0), this));
-    }
-
-    @Override
-    public void onClose(WatcherException e) {
-        if (e == null) {
-            return;
-        }
-
-        if (e.isHttpGone()) {
-            LOGGER.warn("Received error for watch, will try to reconnect.", e);
-            registerWatch(this.component);
-        } else {
-            // Note that this should not happen normally, since fabric8 client handles reconnect.
-            // In case it tries to reconnect this method is not called.
-            LOGGER.error("Unexpected error happened with watch. Will exit.", e);
-            Quarkus.asyncExit(1);
-        }
     }
 }

--- a/shard-operator/src/main/kubernetes/minikube.yml
+++ b/shard-operator/src/main/kubernetes/minikube.yml
@@ -32,6 +32,12 @@ rules:
       - ingresses
     verbs:
       - "*"
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - "*"
   # add here the core resources we need to manage
   #- apiGroups:
   #    - ""

--- a/shard-operator/src/main/kubernetes/openshift.yml
+++ b/shard-operator/src/main/kubernetes/openshift.yml
@@ -32,6 +32,12 @@ rules:
       - routes
     verbs:
       - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - "*"
   # add here the core resources we need to manage
   #- apiGroups:
   #    - ""

--- a/shard-operator/src/main/kubernetes/sample.yml
+++ b/shard-operator/src/main/kubernetes/sample.yml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: bridge-fleet-shard-operator
 spec:
   # just a placeholder, at this time the operator won't deploy anything
-  image: my-image:latest
+  image: openbridge/ingress:latest
   bridgeName: my-bridge
   customerId: kermit
   id: my-bridge-ingress

--- a/shard-operator/src/main/resources/templates/bridge-ingress-service.yaml
+++ b/shard-operator/src/main/resources/templates/bridge-ingress-service.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: bridge-fleet-shard-operator # used for filtering of Deployments created by the controller
     app.kubernetes.io/created-by: bridge-fleet-shard-operator # Specify the operator
     app.kubernetes.io/component: ingress # used to specify the component
+    app.kubernetes.io/instance: ""
   ownerReferences: # used for finding which BridgeIngress/Processor does this Deployment belong to
     - apiVersion: ""
       kind: ""

--- a/shard-operator/src/main/resources/templates/service-monitor.yaml
+++ b/shard-operator/src/main/resources/templates/service-monitor.yaml
@@ -5,7 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: bridge-fleet-shard-operator # used for filtering of Deployments created by the controller
     app.kubernetes.io/created-by: bridge-fleet-shard-operator # Specify the operator
-    app.kubernetes.io/component: service-monitor # used to specify the component
+    app.kubernetes.io/component: ingress # used to specify the component
+    app.kubernetes.io/instance: ""
   ownerReferences: # used for finding which BridgeIngress/Processor does this Deployment belong to
     - apiVersion: ""
       kind: ""

--- a/shard-operator/src/main/resources/templates/service-monitor.yaml
+++ b/shard-operator/src/main/resources/templates/service-monitor.yaml
@@ -3,9 +3,6 @@ kind: ServiceMonitor
 metadata:
   name: ""
   labels:
-    app.kubernetes.io/managed-by: bridge-fleet-shard-operator # used for filtering of Deployments created by the controller
-    app.kubernetes.io/created-by: bridge-fleet-shard-operator # Specify the operator
-    app.kubernetes.io/component: ingress # used to specify the component
     app.kubernetes.io/instance: ""
   ownerReferences: # used for finding which BridgeIngress/Processor does this Deployment belong to
     - apiVersion: ""

--- a/shard-operator/src/main/resources/templates/service-monitor.yaml
+++ b/shard-operator/src/main/resources/templates/service-monitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ""
+  labels:
+    app.kubernetes.io/managed-by: bridge-fleet-shard-operator # used for filtering of Deployments created by the controller
+    app.kubernetes.io/created-by: bridge-fleet-shard-operator # Specify the operator
+    app.kubernetes.io/component: service-monitor # used to specify the component
+  ownerReferences: # used for finding which BridgeIngress/Processor does this Deployment belong to
+    - apiVersion: ""
+      kind: ""
+      name: ""
+      uid: ""
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: ""
+  endpoints:
+    - port: web

--- a/shard-operator/src/main/resources/templates/service-monitor.yaml
+++ b/shard-operator/src/main/resources/templates/service-monitor.yaml
@@ -17,3 +17,6 @@ spec:
       app.kubernetes.io/instance: ""
   endpoints:
     - port: web
+      interval: 30s
+      path: /q/metrics
+      scheme: http

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceTest.java
@@ -41,6 +41,7 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
     CustomerNamespaceProvider customerNamespaceProvider;
 
     @Test
+    @WithPrometheus
     public void testBridgesAreDeployed() throws JsonProcessingException, InterruptedException {
         List<BridgeDTO> bridgeDTOS = new ArrayList<>();
         bridgeDTOS.add(new BridgeDTO("myId-1", "myName-1", "myEndpoint", TestSupport.CUSTOMER_ID, BridgeStatus.REQUESTED));

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/PrometheusRegisterInterceptor.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/PrometheusRegisterInterceptor.java
@@ -1,0 +1,37 @@
+package com.redhat.service.bridge.shard.operator;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import com.redhat.service.bridge.shard.operator.monitoring.ServiceMonitorClient;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import static com.redhat.service.bridge.shard.operator.monitoring.ServiceMonitorClient.SERVICE_MONITOR_CRD_NAME;
+
+/**
+ * Test cases that requires Prometheus should inherit from this base Test Case
+ */
+@WithPrometheus
+@Interceptor
+@Priority(1000)
+public class PrometheusRegisterInterceptor {
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @AroundInvoke
+    public Object registerPrometheus(InvocationContext context) throws Exception {
+        if (!ServiceMonitorClient.isServiceMonitorAvailable(kubernetesClient)) {
+            final CustomResourceDefinition serviceMonitorCRD =
+                    kubernetesClient.apiextensions().v1().customResourceDefinitions().load(this.getClass().getResourceAsStream("/k8s/servicemonitor.v1.crd.yaml")).get();
+            kubernetesClient.apiextensions().v1().customResourceDefinitions().withName(SERVICE_MONITOR_CRD_NAME).create(serviceMonitorCRD);
+        }
+
+        return context.proceed();
+    }
+}

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/WithPrometheus.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/WithPrometheus.java
@@ -1,0 +1,15 @@
+package com.redhat.service.bridge.shard.operator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.METHOD, ElementType.TYPE })
+public @interface WithPrometheus {
+
+}

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceTest.java
@@ -59,6 +59,10 @@ public class ServiceMonitorServiceTest {
 
         // Then
         assertThat(serviceMonitor).isPresent();
+        // check: https://prometheus-operator.dev/docs/operator/troubleshooting/#overview-of-servicemonitor-tagging-and-related-elements
+        assertThat(serviceMonitor.get().getSpec().getSelector().getMatchLabels()).containsEntry("app.kubernetes.io/instance", deployment.getMetadata().getName());
+        assertThat(serviceMonitor.get().getMetadata().getLabels()).containsEntry("app.kubernetes.io/instance", deployment.getMetadata().getName());
+        assertThat(service.getMetadata().getLabels()).containsEntry("app.kubernetes.io/instance", deployment.getMetadata().getName());
     }
 
     private void registerServiceMonitor() {

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceTest.java
@@ -1,0 +1,69 @@
+package com.redhat.service.bridge.shard.operator.monitoring;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
+import com.redhat.service.bridge.shard.operator.BridgeIngressService;
+import com.redhat.service.bridge.shard.operator.TestSupport;
+import com.redhat.service.bridge.shard.operator.resources.BridgeIngress;
+import com.redhat.service.bridge.shard.operator.utils.KubernetesResourcePatcher;
+
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+
+import static com.redhat.service.bridge.shard.operator.monitoring.ServiceMonitorClient.SERVICE_MONITOR_CRD_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+@WithKubernetesTestServer()
+public class ServiceMonitorServiceTest {
+
+    @Inject
+    ServiceMonitorService serviceMonitorService;
+
+    @Inject
+    BridgeIngressService bridgeIngressService;
+
+    @Inject
+    KubernetesResourcePatcher kubernetesResourcePatcher;
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @BeforeEach
+    void setup() {
+        kubernetesResourcePatcher.cleanUp();
+    }
+
+    @Test
+    void fetchOrCreateServiceMonitor() {
+        // Given
+        this.registerServiceMonitor();
+        final BridgeDTO bridge = TestSupport.newAvailableBridgeDTO();
+        final BridgeIngress bridgeIngress = BridgeIngress.fromDTO(bridge, "default", TestSupport.INGRESS_IMAGE);
+        final Deployment deployment = bridgeIngressService.fetchOrCreateBridgeIngressDeployment(bridgeIngress);
+        final Service service = bridgeIngressService.fetchOrCreateBridgeIngressService(bridgeIngress, deployment);
+
+        // When
+        final Optional<ServiceMonitor> serviceMonitor = serviceMonitorService.fetchOrCreateServiceMonitor(bridgeIngress, service);
+
+        // Then
+        assertThat(serviceMonitor).isPresent();
+    }
+
+    private void registerServiceMonitor() {
+        final CustomResourceDefinition serviceMonitorCRD =
+                kubernetesClient.apiextensions().v1().customResourceDefinitions().load(this.getClass().getResourceAsStream("/k8s/servicemonitor.v1.crd.yaml")).get();
+        kubernetesClient.apiextensions().v1().customResourceDefinitions().withName(SERVICE_MONITOR_CRD_NAME).create(serviceMonitorCRD);
+    }
+}

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/providers/TemplateProviderTest.java
@@ -117,7 +117,6 @@ public class TemplateProviderTest {
     }
 
     private void assertLabels(ObjectMeta meta, String component) {
-        assertThat(meta.getLabels().size()).isEqualTo(3);
         assertThat(meta.getLabels().get(LabelsBuilder.COMPONENT_LABEL)).isEqualTo(component);
         assertThat(meta.getLabels().get(LabelsBuilder.MANAGED_BY_LABEL)).isEqualTo(LabelsBuilder.OPERATOR_NAME);
         assertThat(meta.getLabels().get(LabelsBuilder.CREATED_BY_LABEL)).isEqualTo(LabelsBuilder.OPERATOR_NAME);

--- a/shard-operator/src/test/resources/k8s/servicemonitor.v1.crd.yaml
+++ b/shard-operator/src/test/resources/k8s/servicemonitor.v1.crd.yaml
@@ -1,0 +1,627 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.2
+  creationTimestamp: "2021-12-03T14:46:16Z"
+  generation: 1
+  name: servicemonitors.monitoring.coreos.com
+  resourceVersion: "2348718"
+  uid: ecfb0b1b-1ca1-47e8-ba4f-dca99fadd928
+spec:
+  conversion:
+    strategy: None
+  group: monitoring.coreos.com
+  names:
+    categories:
+      - prometheus-operator
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    singular: servicemonitor
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ServiceMonitor defines monitoring for a set of services.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Specification of desired Service selection for target discovery
+                by Prometheus.
+              properties:
+                endpoints:
+                  description: A list of endpoints allowed as part of this ServiceMonitor.
+                  items:
+                    description: Endpoint defines a scrapeable endpoint serving Prometheus
+                      metrics.
+                    properties:
+                      authorization:
+                        description: Authorization section for this endpoint
+                        properties:
+                          credentials:
+                            description: The secret's key that contains the credentials
+                              of the request
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          type:
+                            description: Set the authentication type. Defaults to Bearer,
+                              Basic will cause an error
+                            type: string
+                        type: object
+                      basicAuth:
+                        description: 'BasicAuth allow an endpoint to authenticate over
+                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                        properties:
+                          password:
+                            description: The secret in the service monitor namespace
+                              that contains the password for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          username:
+                            description: The secret in the service monitor namespace
+                              that contains the username for authentication.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                        type: object
+                      bearerTokenFile:
+                        description: File to read bearer token for scraping targets.
+                        type: string
+                      bearerTokenSecret:
+                        description: Secret to mount to read bearer token for scraping
+                          targets. The secret needs to be in the same namespace as the
+                          service monitor and accessible by the Prometheus Operator.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                      honorLabels:
+                        description: HonorLabels chooses the metric's labels on collisions
+                          with target labels.
+                        type: boolean
+                      honorTimestamps:
+                        description: HonorTimestamps controls whether Prometheus respects
+                          the timestamps present in scraped data.
+                        type: boolean
+                      interval:
+                        description: Interval at which metrics should be scraped
+                        type: string
+                      metricRelabelings:
+                        description: MetricRelabelConfigs to apply to samples before
+                          ingestion.
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex replace
+                                is performed if the regular expression matches. Regex
+                                capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      oauth2:
+                        description: OAuth2 for the URL. Only valid in Prometheus versions
+                          2.27.0 and newer.
+                        properties:
+                          clientId:
+                            description: The secret or configmap containing the OAuth2
+                              client id
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                          clientSecret:
+                            description: The secret containing the OAuth2 client secret
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          endpointParams:
+                            additionalProperties:
+                              type: string
+                            description: Parameters to append to the token URL
+                            type: object
+                          scopes:
+                            description: OAuth2 scopes used for the token request
+                            items:
+                              type: string
+                            type: array
+                          tokenUrl:
+                            description: The URL to fetch the token from
+                            minLength: 1
+                            type: string
+                        required:
+                          - clientId
+                          - clientSecret
+                          - tokenUrl
+                        type: object
+                      params:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Optional HTTP URL parameters
+                        type: object
+                      path:
+                        description: HTTP path to scrape for metrics.
+                        type: string
+                      port:
+                        description: Name of the service port this endpoint refers to.
+                          Mutually exclusive with targetPort.
+                        type: string
+                      proxyUrl:
+                        description: ProxyURL eg http://proxyserver:2195 Directs scrapes
+                          to proxy through this endpoint.
+                        type: string
+                      relabelings:
+                        description: 'RelabelConfigs to apply to samples before scraping.
+                        Prometheus Operator automatically adds relabelings for a few
+                        standard Kubernetes fields and replaces original scrape job
+                        name with __tmp_prometheus_job_name. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of the
+                          label set, being applied to samples before ingestion. It
+                          defines `<metric_relabel_configs>`-section of Prometheus
+                          configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching.
+                                Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source
+                                label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted
+                                value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex replace
+                                is performed if the regular expression matches. Regex
+                                capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source
+                                label values. default is ';'.
+                              type: string
+                            sourceLabels:
+                              description: The source labels select values from existing
+                                labels. Their content is concatenated using the configured
+                                separator and matched against the configured regular
+                                expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: Label to which the resulting value is written
+                                in a replace action. It is mandatory for replace actions.
+                                Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
+                      scheme:
+                        description: HTTP scheme to use for scraping.
+                        type: string
+                      scrapeTimeout:
+                        description: Timeout after which the scrape is ended
+                        type: string
+                      targetPort:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: Name or number of the target port of the Pod behind
+                          the Service, the port must be specified with container port
+                          property. Mutually exclusive with port.
+                        x-kubernetes-int-or-string: true
+                      tlsConfig:
+                        description: TLS configuration to use when scraping the endpoint
+                        properties:
+                          ca:
+                            description: Struct containing the CA cert to use for the
+                              targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                          caFile:
+                            description: Path to the CA cert in the Prometheus container
+                              to use for the targets.
+                            type: string
+                          cert:
+                            description: Struct containing the client cert file for
+                              the targets.
+                            properties:
+                              configMap:
+                                description: ConfigMap containing data to use for the
+                                  targets.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              secret:
+                                description: Secret containing data to use for the targets.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                          certFile:
+                            description: Path to the client cert file in the Prometheus
+                              container for the targets.
+                            type: string
+                          insecureSkipVerify:
+                            description: Disable target certificate validation.
+                            type: boolean
+                          keyFile:
+                            description: Path to the client key file in the Prometheus
+                              container for the targets.
+                            type: string
+                          keySecret:
+                            description: Secret containing the client key file for the
+                              targets.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                          serverName:
+                            description: Used to verify the hostname for the targets.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                jobLabel:
+                  description: "Chooses the label of the Kubernetes `Endpoints`. Its
+                  value will be used for the `job`-label's value of the created metrics.
+                  \n Default & fallback value: the name of the respective Kubernetes
+                  `Endpoint`."
+                  type: string
+                labelLimit:
+                  description: Per-scrape limit on number of labels that will be accepted
+                    for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                  format: int64
+                  type: integer
+                labelNameLengthLimit:
+                  description: Per-scrape limit on length of labels name that will be
+                    accepted for a sample. Only valid in Prometheus versions 2.27.0
+                    and newer.
+                  format: int64
+                  type: integer
+                labelValueLengthLimit:
+                  description: Per-scrape limit on length of labels value that will
+                    be accepted for a sample. Only valid in Prometheus versions 2.27.0
+                    and newer.
+                  format: int64
+                  type: integer
+                namespaceSelector:
+                  description: Selector to select which namespaces the Kubernetes Endpoints
+                    objects are discovered from.
+                  properties:
+                    any:
+                      description: Boolean describing whether all namespaces are selected
+                        in contrast to a list restricting them.
+                      type: boolean
+                    matchNames:
+                      description: List of namespace names.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                podTargetLabels:
+                  description: PodTargetLabels transfers labels on the Kubernetes `Pod`
+                    onto the created metrics.
+                  items:
+                    type: string
+                  type: array
+                sampleLimit:
+                  description: SampleLimit defines per-scrape limit on number of scraped
+                    samples that will be accepted.
+                  format: int64
+                  type: integer
+                selector:
+                  description: Selector to select Endpoints objects.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the key
+                          and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship to
+                              a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                targetLabels:
+                  description: TargetLabels transfers labels from the Kubernetes `Service`
+                    onto the created metrics. All labels set in `selector.matchLabels`
+                    are automatically transferred.
+                  items:
+                    type: string
+                  type: array
+                targetLimit:
+                  description: TargetLimit defines a limit on the number of scraped
+                    targets that will be accepted.
+                  format: int64
+                  type: integer
+              required:
+                - endpoints
+                - selector
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    categories:
+      - prometheus-operator
+    kind: ServiceMonitor
+    listKind: ServiceMonitorList
+    plural: servicemonitors
+    singular: servicemonitor
+  conditions:
+    - lastTransitionTime: "2021-12-03T14:46:16Z"
+      message: no conflicts found
+      reason: NoConflicts
+      status: "True"
+      type: NamesAccepted
+    - lastTransitionTime: "2021-12-03T14:46:16Z"
+      message: the initial names have been accepted
+      reason: InitialNamesAccepted
+      status: "True"
+      type: Established
+  storedVersions:
+    - v1


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

[MGDOBR-95](https://issues.redhat.com/browse/MGDOBR-95) 

In this PR we introduce the `ServiceMonitor` optionally created by the Shard Operator when creating the `BridgeIngress`. Additionally, we added the metrics endpoints to the Ingress application.

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
