### PR TITLE
[MGDOBR-163] Adding Pormetheus ServiceMonitor to BridgeExecutor

### DIFF
--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeExecutorController.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeExecutorController.java
@@ -87,11 +87,13 @@ public class BridgeExecutorController implements ResourceController<BridgeExecut
             return UpdateControl.updateStatusSubResource(bridgeExecutor);
         }
 
-        Optional<ServiceMonitor> serviceMonitor = monitorService.fetchOrCreateServiceMonitor(bridgeExecutor, service);
+        Optional<ServiceMonitor> serviceMonitor = monitorService.fetchOrCreateServiceMonitor(bridgeExecutor, service, BridgeExecutor.COMPONENT_NAME);
         if (serviceMonitor.isPresent()) {
             // this is an optional resource
             LOGGER.debug("Executor service monitor resource BridgeExecutor: '{}' in namespace '{}' is ready", bridgeExecutor.getMetadata().getName(), bridgeExecutor.getMetadata().getNamespace());
         } else {
+            LOGGER.warn("Executor service monitor resource BridgeExecutor: '{}' in namespace '{}' is failed to deploy, Prometheus not installed.", bridgeExecutor.getMetadata().getName(),
+                    bridgeExecutor.getMetadata().getNamespace());
             bridgeExecutor.getStatus().markConditionFalse(ConditionType.Ready, ConditionReason.PrometheusUnavailable, ConditionMessages.PROMETHEUS_UNVAILABLE);
             notifyManager(bridgeExecutor, BridgeStatus.FAILED);
             return UpdateControl.updateStatusSubResource(bridgeExecutor);

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeExecutorController.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeExecutorController.java
@@ -1,5 +1,7 @@
 package com.redhat.service.bridge.shard.operator.controllers;
 
+import java.util.Optional;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -10,16 +12,20 @@ import com.redhat.service.bridge.infra.models.dto.BridgeStatus;
 import com.redhat.service.bridge.infra.models.dto.ProcessorDTO;
 import com.redhat.service.bridge.shard.operator.BridgeExecutorService;
 import com.redhat.service.bridge.shard.operator.ManagerSyncService;
+import com.redhat.service.bridge.shard.operator.monitoring.ServiceMonitorService;
 import com.redhat.service.bridge.shard.operator.resources.BridgeExecutor;
+import com.redhat.service.bridge.shard.operator.resources.ConditionMessages;
 import com.redhat.service.bridge.shard.operator.resources.ConditionReason;
 import com.redhat.service.bridge.shard.operator.resources.ConditionType;
 import com.redhat.service.bridge.shard.operator.watchers.DeploymentEventSource;
 import com.redhat.service.bridge.shard.operator.watchers.ServiceEventSource;
+import com.redhat.service.bridge.shard.operator.watchers.monitoring.ServiceMonitorEventSource;
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
 import io.javaoperatorsdk.operator.api.Context;
 import io.javaoperatorsdk.operator.api.Controller;
 import io.javaoperatorsdk.operator.api.DeleteControl;
@@ -42,12 +48,17 @@ public class BridgeExecutorController implements ResourceController<BridgeExecut
     @Inject
     BridgeExecutorService bridgeExecutorService;
 
+    @Inject
+    ServiceMonitorService monitorService;
+
     @Override
     public void init(EventSourceManager eventSourceManager) {
         DeploymentEventSource deploymentEventSource = DeploymentEventSource.createAndRegisterWatch(kubernetesClient, BridgeExecutor.COMPONENT_NAME);
         eventSourceManager.registerEventSource("bridge-processor-deployment-event-source", deploymentEventSource);
         ServiceEventSource serviceEventSource = ServiceEventSource.createAndRegisterWatch(kubernetesClient, BridgeExecutor.COMPONENT_NAME);
         eventSourceManager.registerEventSource("bridge-processor-service-event-source", serviceEventSource);
+        Optional<ServiceMonitorEventSource> serviceMonitorEventSource = ServiceMonitorEventSource.createAndRegisterWatch(kubernetesClient, BridgeExecutor.COMPONENT_NAME);
+        serviceMonitorEventSource.ifPresent(monitorEventSource -> eventSourceManager.registerEventSource("bridge-processor-monitoring-event-source", monitorEventSource));
     }
 
     @Override
@@ -75,6 +86,17 @@ public class BridgeExecutorController implements ResourceController<BridgeExecut
             bridgeExecutor.getStatus().markConditionTrue(ConditionType.Augmentation, ConditionReason.ServiceNotReady);
             return UpdateControl.updateStatusSubResource(bridgeExecutor);
         }
+
+        Optional<ServiceMonitor> serviceMonitor = monitorService.fetchOrCreateServiceMonitor(bridgeExecutor, service);
+        if (serviceMonitor.isPresent()) {
+            // this is an optional resource
+            LOGGER.debug("Executor service monitor resource BridgeExecutor: '{}' in namespace '{}' is ready", bridgeExecutor.getMetadata().getName(), bridgeExecutor.getMetadata().getNamespace());
+        } else {
+            bridgeExecutor.getStatus().markConditionFalse(ConditionType.Ready, ConditionReason.PrometheusUnavailable, ConditionMessages.PROMETHEUS_UNVAILABLE);
+            notifyManager(bridgeExecutor, BridgeStatus.FAILED);
+            return UpdateControl.updateStatusSubResource(bridgeExecutor);
+        }
+
         LOGGER.debug("Executor service BridgeProcessor: '{}' in namespace '{}' is ready", bridgeExecutor.getMetadata().getName(), bridgeExecutor.getMetadata().getNamespace());
 
         if (!bridgeExecutor.getStatus().isReady()) {

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressController.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressController.java
@@ -112,12 +112,13 @@ public class BridgeIngressController implements ResourceController<BridgeIngress
         }
         LOGGER.debug("Ingress networking resource BridgeIngress: '{}' in namespace '{}' is ready", bridgeIngress.getMetadata().getName(), bridgeIngress.getMetadata().getNamespace());
 
-        Optional<ServiceMonitor> serviceMonitor = monitorService.fetchOrCreateServiceMonitor(bridgeIngress, service);
+        Optional<ServiceMonitor> serviceMonitor = monitorService.fetchOrCreateServiceMonitor(bridgeIngress, service, BridgeIngress.COMPONENT_NAME);
         if (serviceMonitor.isPresent()) {
             // this is an optional resource
             LOGGER.debug("Ingress monitor resource BridgeIngress: '{}' in namespace '{}' is ready", bridgeIngress.getMetadata().getName(), bridgeIngress.getMetadata().getNamespace());
         } else {
-            // TODO: the message will be a constant on MGDOBR-163
+            LOGGER.warn("Ingress monitor resource BridgeIngress: '{}' in namespace '{}' is failed to deploy, Prometheus not installed.", bridgeIngress.getMetadata().getName(),
+                    bridgeIngress.getMetadata().getNamespace());
             bridgeIngress.getStatus().markConditionFalse(ConditionType.Ready, ConditionReason.PrometheusUnavailable, ConditionMessages.PROMETHEUS_UNVAILABLE);
             notifyManager(bridgeIngress, BridgeStatus.FAILED);
             return UpdateControl.updateStatusSubResource(bridgeIngress);

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorService.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorService.java
@@ -16,7 +16,8 @@ public interface ServiceMonitorService {
      *
      * @param service the target Kubernetes {@link Service} to bind the monitoring resource.
      * @param resource the custom resource managed by this operator (e.g. BridgeIngress).
+     * @param componentName the name of the component created by this
      * @return an {@link Optional} {@link ServiceMonitor} if Prometheus Operator is installed in the cluster.
      */
-    Optional<ServiceMonitor> fetchOrCreateServiceMonitor(final CustomResource resource, final Service service);
+    Optional<ServiceMonitor> fetchOrCreateServiceMonitor(final CustomResource resource, final Service service, final String componentName);
 }

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/ConditionMessages.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/resources/ConditionMessages.java
@@ -1,0 +1,10 @@
+package com.redhat.service.bridge.shard.operator.resources;
+
+public final class ConditionMessages {
+
+    public static final String PROMETHEUS_UNVAILABLE = "ServiceMonitor CRD not available";
+
+    private ConditionMessages() {
+    }
+
+}

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/monitoring/ServiceMonitorServiceTest.java
@@ -55,7 +55,7 @@ public class ServiceMonitorServiceTest {
         final Service service = bridgeIngressService.fetchOrCreateBridgeIngressService(bridgeIngress, deployment);
 
         // When
-        final Optional<ServiceMonitor> serviceMonitor = serviceMonitorService.fetchOrCreateServiceMonitor(bridgeIngress, service);
+        final Optional<ServiceMonitor> serviceMonitor = serviceMonitorService.fetchOrCreateServiceMonitor(bridgeIngress, service, "ingress");
 
         // Then
         assertThat(serviceMonitor).isPresent();
@@ -64,6 +64,7 @@ public class ServiceMonitorServiceTest {
         assertThat(serviceMonitor.get().getMetadata().getLabels()).containsEntry(LabelsBuilder.INSTANCE_LABEL, deployment.getMetadata().getName());
         assertThat(serviceMonitor.get().getMetadata().getLabels()).containsEntry(LabelsBuilder.MANAGED_BY_LABEL, LabelsBuilder.OPERATOR_NAME);
         assertThat(serviceMonitor.get().getMetadata().getLabels()).containsEntry(LabelsBuilder.CREATED_BY_LABEL, LabelsBuilder.OPERATOR_NAME);
+        assertThat(serviceMonitor.get().getMetadata().getLabels()).containsEntry(LabelsBuilder.COMPONENT_LABEL, "ingress");
         assertThat(service.getMetadata().getLabels()).containsEntry(LabelsBuilder.INSTANCE_LABEL, deployment.getMetadata().getName());
     }
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

[MGDOBR-163](https://issues.redhat.com/browse/MGDOBR-163) 

Small change to `BridgeExecutor` to include `ServiceMonitor`. If Prometheus is not available, the CR will change its status to `Ready: false` and will notify the manager, so the component status will be `FAILED`.

I tried to do a small refactoring of the Controllers since they have almost the same algorithm. It's fairly easy to do, but the change would be huge. I'd rather have it in another PR. @r00ta @robpblake wdyt? I can open a JIRA to make the `ShardController` and `ShardResource` to manage the common bits between these two.

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
