### PR TITLE
MGDOBR-207: fix refresh token expiration and add safe buffer to refresh the token

### DIFF
--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceImpl.java
@@ -191,8 +191,7 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
     }
 
     private Uni<HttpResponse<Buffer>> getAuthenticatedRequest(HttpRequest<Buffer> request, Function<HttpRequest<Buffer>, Uni<HttpResponse<Buffer>>> executor) {
-        Tokens tokens = currentTokens;
-        if (tokens.isAccessTokenExpired() || tokens.isAccessTokenWithinRefreshInterval()) {
+        if (currentTokens.isAccessTokenExpired() || currentTokens.isAccessTokenWithinRefreshInterval()) {
             LOGGER.debug("Shard authentication token has expired");
             refreshTokens();
         }

--- a/shard-operator/src/main/resources/application.properties
+++ b/shard-operator/src/main/resources/application.properties
@@ -21,7 +21,7 @@ quarkus.oidc-client.credentials.secret=${EVENT_BRIDGE_SSO_SECRET:secret}
 quarkus.oidc-client.grant.type=password
 quarkus.oidc-client.grant-options.password.username=${KEYCLOAK_USER:kermit}
 quarkus.oidc-client.grant-options.password.password=${KEYCLOAK_PASSWORD:thefrog}
-
+quarkus.oidc-client.refresh-token-time-skew=30S
 
 %minikube.quarkus.kubernetes.deployment-target=minikube
 %minikube.quarkus.container-image.build=true


### PR DESCRIPTION
[MGDOBR-207](https://issues.redhat.com/browse/MGDOBR-207) 

This PR aims to add 30s buffer to the token expiration check. In addition to that, in case the refresh token has expired, a new fresh token is retrieved. 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
