### PR TITLE
MGDOBR-222: fix manager start with disabled rhoas

### DIFF
--- a/manager/src/main/resources/application.properties
+++ b/manager/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-event-bridge.feature-flags.rhoas-enabled=false
-event-bridge.manager.rhoas.timeout-seconds=60
-
 quarkus.swagger-ui.always-include=true
 
 # Database
@@ -26,6 +23,14 @@ quarkus.flyway.create-schemas=true
 # SSO
 quarkus.oidc.auth-server-url=${EVENT_BRIDGE_SSO_URL}
 quarkus.oidc.client-id=${EVENT_BRIDGE_SSO_CLIENT_ID}
+
+# RHOAS
+event-bridge.feature-flags.rhoas-enabled=false
+event-bridge.manager.rhoas.timeout-seconds=60
+# These three variables must be set to a non-empty string even if event-bridge.feature-flags.rhoas-enabled is false
+event-bridge.rhoas.mgmt-api.host=empty
+event-bridge.rhoas.instance-api.host=empty
+event-bridge.rhoas.sso.red-hat.refresh-token=empty
 
 ## Dev Profile Overrides
 %dev.quarkus.datasource.db-kind=postgresql

--- a/rhoas-client/src/main/resources/application.properties
+++ b/rhoas-client/src/main/resources/application.properties
@@ -1,13 +1,13 @@
 ### OIDC Clients for RHOAS
 quarkus.oidc-client.client-enabled=false
 # Red Hat SSO (refresh token read from "event-bridge.rhoas.sso.red-hat.refresh-token" property)
-quarkus.oidc-client.red-hat-sso.auth-server-url=${event-bridge.rhoas.sso.red-hat.auth-server-url}
-quarkus.oidc-client.red-hat-sso.client-id=${event-bridge.rhoas.sso.red-hat.client-id}
+quarkus.oidc-client.red-hat-sso.auth-server-url=${event-bridge.rhoas.sso.red-hat.auth-server-url:}
+quarkus.oidc-client.red-hat-sso.client-id=${event-bridge.rhoas.sso.red-hat.client-id:}
 quarkus.oidc-client.red-hat-sso.credentials.secret=secret
 quarkus.oidc-client.red-hat-sso.grant.type=refresh
 # MAS SSO
-quarkus.oidc-client.mas-sso.auth-server-url=${event-bridge.rhoas.sso.mas.auth-server-url}
-quarkus.oidc-client.mas-sso.client-id=${event-bridge.rhoas.sso.mas.client-id}
-quarkus.oidc-client.mas-sso.credentials.secret=${event-bridge.rhoas.sso.mas.client-secret}
+quarkus.oidc-client.mas-sso.auth-server-url=${event-bridge.rhoas.sso.mas.auth-server-url:}
+quarkus.oidc-client.mas-sso.client-id=${event-bridge.rhoas.sso.mas.client-id:}
+quarkus.oidc-client.mas-sso.credentials.secret=${event-bridge.rhoas.sso.mas.client-secret:}
 quarkus.oidc-client.mas-sso.grant.type=client
 quarkus.oidc-client.mas-sso.scopes=email


### PR DESCRIPTION
This is the cleanest solution I found to quickly fix the start of the manager with disabled RHOAS, without changing the existing code too much.

[MGDOBR-222](https://issues.redhat.com/browse/MGDOBR-222) 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
