### PR TITLE
[MGDOBR-114] Notify Manager if Bridge Ingress Fails To Deploy

### DIFF
--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressController.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressController.java
@@ -21,6 +21,7 @@ import com.redhat.service.bridge.shard.operator.networking.NetworkingService;
 import com.redhat.service.bridge.shard.operator.resources.BridgeIngress;
 import com.redhat.service.bridge.shard.operator.resources.ConditionReason;
 import com.redhat.service.bridge.shard.operator.resources.ConditionType;
+import com.redhat.service.bridge.shard.operator.utils.DeploymentStatusUtils;
 import com.redhat.service.bridge.shard.operator.watchers.DeploymentEventSource;
 import com.redhat.service.bridge.shard.operator.watchers.ServiceEventSource;
 import com.redhat.service.bridge.shard.operator.watchers.monitoring.ServiceMonitorEventSource;
@@ -38,9 +39,6 @@ import io.javaoperatorsdk.operator.api.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.AbstractEventSource;
 import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
 
-/**
- * To be implemented on <a href="https://issues.redhat.com/browse/MGDOBR-93">MGDOBR-93</a>
- */
 @ApplicationScoped
 @Controller
 public class BridgeIngressController implements ResourceController<BridgeIngress> {
@@ -87,9 +85,14 @@ public class BridgeIngressController implements ResourceController<BridgeIngress
             LOGGER.debug("Ingress deployment BridgeIngress: '{}' in namespace '{}' is NOT ready", bridgeIngress.getMetadata().getName(),
                     bridgeIngress.getMetadata().getNamespace());
 
-            // TODO: notify the manager if in FailureState: .status.Type = Ready and .status.Reason = DeploymentFailed
-
             bridgeIngress.getStatus().setConditionsFromDeployment(deployment);
+            boolean failed = DeploymentStatusUtils.isStatusReplicaFailure(deployment);
+            if (failed) {
+                String failureReason = DeploymentStatusUtils.getReasonAndMessageForReplicaFailure(deployment);
+                LOGGER.warn("Ingress deployment BridgeIngress: '{}' in namespace '{}' has failed with reason: '{}'", bridgeIngress.getMetadata().getName(), bridgeIngress.getMetadata().getNamespace(),
+                        failureReason);
+                notifyManager(bridgeIngress, BridgeStatus.FAILED);
+            }
             return UpdateControl.updateStatusSubResource(bridgeIngress);
         }
         LOGGER.debug("Ingress deployment BridgeIngress: '{}' in namespace '{}' is ready", bridgeIngress.getMetadata().getName(), bridgeIngress.getMetadata().getNamespace());

--- a/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/utils/DeploymentStatusUtils.java
+++ b/shard-operator/src/main/java/com/redhat/service/bridge/shard/operator/utils/DeploymentStatusUtils.java
@@ -12,8 +12,8 @@ public final class DeploymentStatusUtils {
 
     // https://pkg.go.dev/k8s.io/api/apps/v1#DeploymentConditionType
 
-    private static final String REPLICA_FAILURE = "ReplicaFailure";
-    private static final String STATUS_TRUE = "True";
+    public static final String REPLICA_FAILURE_CONDITION_TYPE = "ReplicaFailure";
+    public static final String STATUS_TRUE = "True";
 
     private DeploymentStatusUtils() {
     }
@@ -22,11 +22,11 @@ public final class DeploymentStatusUtils {
         if (!hasValidConditions(d)) {
             return false;
         }
-        return d.getStatus().getConditions().stream().anyMatch(c -> REPLICA_FAILURE.equalsIgnoreCase(c.getType()) && STATUS_TRUE.equalsIgnoreCase(c.getStatus()));
+        return d.getStatus().getConditions().stream().anyMatch(c -> REPLICA_FAILURE_CONDITION_TYPE.equalsIgnoreCase(c.getType()) && STATUS_TRUE.equalsIgnoreCase(c.getStatus()));
     }
 
     public static String getReasonAndMessageForReplicaFailure(final Deployment d) {
-        return getReasonAndMessage(REPLICA_FAILURE, d);
+        return getReasonAndMessage(REPLICA_FAILURE_CONDITION_TYPE, d);
     }
 
     private static String getReasonAndMessage(final String type, final Deployment d) {

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/ManagerSyncServiceTest.java
@@ -67,12 +67,12 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
                 .pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(
                         () -> {
-                            kubernetesResourcePatcher.patchReadyDeploymentOrFail(firstBridgeName, customerNamespace);
-                            kubernetesResourcePatcher.patchReadyDeploymentOrFail(secondBridgeName, customerNamespace);
-                            kubernetesResourcePatcher.patchReadyServiceOrFail(firstBridgeName, customerNamespace);
-                            kubernetesResourcePatcher.patchReadyServiceOrFail(secondBridgeName, customerNamespace);
-                            kubernetesResourcePatcher.patchReadyNetworkResourceOrFail(firstBridgeName, customerNamespace);
-                            kubernetesResourcePatcher.patchReadyNetworkResourceOrFail(secondBridgeName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyDeploymentAsReady(firstBridgeName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyDeploymentAsReady(secondBridgeName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyService(firstBridgeName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyService(secondBridgeName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyNetworkResource(firstBridgeName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyNetworkResource(secondBridgeName, customerNamespace);
                         });
 
         assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
@@ -139,8 +139,8 @@ public class ManagerSyncServiceTest extends AbstractShardWireMockTest {
                 .pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(
                         () -> {
-                            kubernetesResourcePatcher.patchReadyDeploymentOrFail(sanitizedName, customerNamespace);
-                            kubernetesResourcePatcher.patchReadyServiceOrFail(sanitizedName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyDeploymentAsReady(sanitizedName, customerNamespace);
+                            kubernetesResourcePatcher.patchReadyService(sanitizedName, customerNamespace);
                         });
         assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
         processor.setStatus(BridgeStatus.AVAILABLE);

--- a/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressControllerTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/bridge/shard/operator/controllers/BridgeIngressControllerTest.java
@@ -1,10 +1,17 @@
 package com.redhat.service.bridge.shard.operator.controllers;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.redhat.service.bridge.infra.api.APIConstants;
+import com.redhat.service.bridge.infra.models.dto.BridgeDTO;
+import com.redhat.service.bridge.infra.models.dto.BridgeStatus;
+import com.redhat.service.bridge.shard.operator.AbstractShardWireMockTest;
 import com.redhat.service.bridge.shard.operator.TestSupport;
 import com.redhat.service.bridge.shard.operator.resources.BridgeIngress;
 import com.redhat.service.bridge.shard.operator.resources.ConditionReason;
@@ -21,12 +28,16 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.kubernetes.client.WithOpenShiftTestServer;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @QuarkusTest
 @WithOpenShiftTestServer
 @QuarkusTestResource(KeycloakResource.class)
-public class BridgeIngressControllerTest {
+public class BridgeIngressControllerTest extends AbstractShardWireMockTest {
 
     @Inject
     BridgeIngressController bridgeIngressController;
@@ -80,6 +91,41 @@ public class BridgeIngressControllerTest {
         assertThat(deployment.getSpec().getTemplate().getMetadata().getLabels()).isNotNull();
         assertThat(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage()).isNotNull();
         assertThat(deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getName()).isNotNull();
+    }
+
+    private Deployment getDeploymentFor(BridgeIngress bridgeIngress) {
+        Deployment deployment = kubernetesClient.apps().deployments().inNamespace(bridgeIngress.getMetadata().getNamespace()).withName(bridgeIngress.getMetadata().getName()).get();
+        assertThat(deployment).isNotNull();
+        return deployment;
+    }
+
+    @Test
+    void testBridgeIngressDeployment_deploymentFails() throws Exception {
+        // Given
+        BridgeIngress bridgeIngress = buildBridgeIngress();
+
+        // When
+        bridgeIngressController.createOrUpdateResource(bridgeIngress, null);
+        Deployment deployment = getDeploymentFor(bridgeIngress);
+
+        // Then
+        kubernetesResourcePatcher.patchDeploymentAsFailed(deployment.getMetadata().getName(), deployment.getMetadata().getNamespace());
+
+        // We expect a single update to Fleet Manager to inform of the Deployment Failure
+        stubBridgeUpdate();
+        CountDownLatch bridgeUpdates = new CountDownLatch(1);
+        addBridgeUpdateRequestListener(bridgeUpdates);
+
+        UpdateControl<BridgeIngress> updateControl = bridgeIngressController.createOrUpdateResource(bridgeIngress, null);
+        assertThat(updateControl.isUpdateStatusSubResource()).isTrue();
+
+        BridgeDTO bridgeDTO = updateControl.getCustomResource().toDTO();
+        bridgeDTO.setStatus(BridgeStatus.FAILED);
+
+        assertThat(bridgeUpdates.await(30, TimeUnit.SECONDS)).isTrue();
+        wireMockServer.verify(putRequestedFor(urlEqualTo(APIConstants.SHARD_API_BASE_PATH))
+                .withRequestBody(equalToJson(objectMapper.writeValueAsString(bridgeDTO)))
+                .withHeader("Content-Type", equalTo("application/json")));
     }
 
     private BridgeIngress buildBridgeIngress() {


### PR DESCRIPTION
[MGDOBR-114](https://issues.redhat.com/browse/MGDOBR-114) 

This PR adds in a notification from Fleet Shard to Fleet Manager in the Event that the Ingress `Deployment` fails to deploy. A Failure is determined by the `Condition`, `ReplicaFailure` having the value `True` on the status of the `Deployment` resource.

This PR does not take into account the duration of the time taken to deploy the Ingress. At the minute, the time limit for deploying the Ingress is unbounded and we will address timeout in [MGDOBR-255](https://issues.redhat.com/browse/MGDOBR-255).

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
