### PR TITLE
MGDOBR 262: Define Cucumber version definition from build-parent/pom.xml for shared-operator-integration-tests

### DIFF
--- a/shard-operator-integration-tests/pom.xml
+++ b/shard-operator-integration-tests/pom.xml
@@ -15,7 +15,6 @@
   <name>Event Bridge :: Shard Operator Integration Tests (Cucumber)</name>
 
   <properties>
-    <cucumber.version>7.0.0</cucumber.version>
     <parallel>false</parallel>
   </properties>
 
@@ -40,19 +39,19 @@
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-java</artifactId>
       <scope>test</scope>
-      <version>${cucumber.version}</version>
+      <version>${version.io.cucumber}</version>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit-platform-engine</artifactId>
       <scope>test</scope>
-      <version>${cucumber.version}</version>
+      <version>${version.io.cucumber}</version>
     </dependency>
     <dependency>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-picocontainer</artifactId>
         <scope>test</scope>
-        <version>${cucumber.version}</version>
+        <version>${version.io.cucumber}</version>
     </dependency>
 
     <dependency>

--- a/shard-operator-integration-tests/pom.xml
+++ b/shard-operator-integration-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>com.redhat.service.bridge</groupId>
@@ -48,10 +48,10 @@
       <version>${version.io.cucumber}</version>
     </dependency>
     <dependency>
-        <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-picocontainer</artifactId>
-        <scope>test</scope>
-        <version>${version.io.cucumber}</version>
+      <groupId>io.cucumber</groupId>
+      <artifactId>cucumber-picocontainer</artifactId>
+      <scope>test</scope>
+      <version>${version.io.cucumber}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Defining Cucumber version definition from build-parent/pom.xml for shared-operator-integration-tests

[MGDOBR-262](https://issues.redhat.com/browse/MGDOBR-262) 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
