### PR TITLE
MGDOBR-263 - Refactor integration tests to be self contained

### DIFF
--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/End2EndTestITStep.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/End2EndTestITStep.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.UUID;
 
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
@@ -40,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class End2EndTestITStep {
 
+    private static String randomBridgeName;
     private static String bridgeId;
     private static String processorId;
     private static String endPoint;
@@ -56,18 +58,18 @@ public class End2EndTestITStep {
                 .statusCode(responseCode);
     }
 
-    @Given("^get list of Bridge instances with access token doesn't contain Bridge \"([^\"]*)\"$")
-    public void getEmptyBridges(String bridgeName) {
+    @Given("get list of Bridge instances with access token doesn't contain randomly generated Bridge")
+    public void generateRandomBridgeName() {
+        End2EndTestITStep.randomBridgeName = "bridge-" + UUID.randomUUID().toString().substring(0, 4);
         BridgeListResponse response = getBridgeList();
         assertThat(response.getKind()).isEqualTo("BridgeList");
-        assertThat(response.getItems()).noneMatch(b -> b.getName().equals(bridgeName));
-
+        assertThat(response.getItems()).noneMatch(b -> b.getName().equals(End2EndTestITStep.randomBridgeName));
     }
 
-    @When("^create a Bridge with name \"([^\"]*)\" with access token$")
-    public void createBridge(String bridgeName) {
-        BridgeResponse response = addBridge(bridgeName);
-        assertThat(response.getName()).isEqualTo(bridgeName);
+    @When("create a Bridge with randomly generated name with access token")
+    public void createRandomBridge() {
+        BridgeResponse response = addBridge(End2EndTestITStep.randomBridgeName);
+        assertThat(response.getName()).isEqualTo(End2EndTestITStep.randomBridgeName);
         assertThat(response.getStatus()).isEqualTo(BridgeStatus.REQUESTED);
         assertThat(response.getEndpoint()).isNull();
         assertThat(response.getPublishedAt()).isNull();
@@ -77,10 +79,10 @@ public class End2EndTestITStep {
         bridgeId = response.getId();
     }
 
-    @Given("^get list of Bridge instances with access token contains Bridge \"([^\"]*)\"")
-    public void testBridgeExists(String bridgeName) {
+    @Then("get list of Bridge instances with access token contains Bridge with randomly generated name")
+    public void testRandomBridgeExists() {
         BridgeListResponse response = getBridgeList();
-        assertThat(response.getItems()).anyMatch(b -> b.getName().equals(bridgeName));
+        assertThat(response.getItems()).anyMatch(b -> b.getName().equals(End2EndTestITStep.randomBridgeName));
     }
 
     @Then("^get Bridge with access token exists in status \"([^\"]*)\" within (\\d+) (?:minute|minutes)$")
@@ -224,6 +226,7 @@ public class End2EndTestITStep {
 
     @And("^the Ingress is Undeployed within (\\d+) (?:minute|minutes)$")
     public void ingressUndeployedWithinMinutes(int timeoutMinutes) {
+        cloudEventStream = new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8));
         Awaitility.await().atMost(Duration.ofMinutes(timeoutMinutes)).pollInterval(Duration.ofSeconds(5)).untilAsserted(() -> jsonRequestWithAuth()
                 .body(cloudEventStream).contentType(ContentType.JSON)
                 .post(endPoint + "/events")

--- a/integration-tests/src/test/resources/features/end2endtestit.feature
+++ b/integration-tests/src/test/resources/features/end2endtestit.feature
@@ -4,12 +4,21 @@ Feature: End to End Bridge integration tests
     Given get list of Bridge instances returns HTTP response code 401
 
   Scenario: Bridge is created and in available state
-    Given get list of Bridge instances with access token doesn't contain Bridge "notificationBridge"
-    When create a Bridge with name "notificationBridge" with access token
-    Then get list of Bridge instances with access token contains Bridge "notificationBridge"
+    Given get list of Bridge instances with access token doesn't contain randomly generated Bridge
+    When create a Bridge with randomly generated name with access token
+    Then get list of Bridge instances with access token contains Bridge with randomly generated name
     Then get Bridge with access token exists in status "AVAILABLE" within 2 minutes
 
+    When delete a Bridge
+    Then the Bridge doesn't exists within 2 minutes
+
+    And the Ingress is Undeployed within 1 minute
+
   Scenario: Processor gets created to the bridge and deployed
+    Given get list of Bridge instances with access token doesn't contain randomly generated Bridge
+    When create a Bridge with randomly generated name with access token
+    Then get list of Bridge instances with access token contains Bridge with randomly generated name
+    Then get Bridge with access token exists in status "AVAILABLE" within 2 minutes
     When add Processor to the Bridge with access token:
     """
     {
@@ -73,14 +82,8 @@ Feature: End to End Bridge integration tests
     }
     """
 
-  Scenario: Bridge, Processor and Ingress gets deleted
     When the Processor is deleted
     Then the Processor doesn't exists within 2 minutes
-
-    When delete a Bridge
-    Then the Bridge doesn't exists within 2 minutes
-
-    And the Ingress is Undeployed within 1 minute
 
   Scenario: Verify Metrics details exist
     Given the Metrics info is exists


### PR DESCRIPTION
[MGDOBR-263](https://issues.redhat.com/browse/MGDOBR-263) 
Currently implemented tests ([MGDOBR-205](https://issues.redhat.com/browse/MGDOBR-205)) depend on each other to be executed in specific order.
This makes them fragile - if a test fails then all subsequent tests will most likely fail too. Also it is not possible to execute a specific test, user needs to execute whole test suite even when interested in one test result.

Purpose of this JIRA is to convert tests to be self contained - every test should be executed separately regardless of other tests or execution order. Every test will be responsible to setup the environment needed.

Acceptance Criteria
- Every test can be executed separately.
- !!!CHANGE: "Every test should clean its resources in case of a successful execution (cleanup during a test failure will be addressed as a separate JIRA)" - From what I've heard we plan to delete all bridges after every test in MGDOBR-264. Therefore I consider deleting of the bridges etc. as unnecessary. Cleanup in the test logic may in my opinion also hide the logic of the test. @Srihari1192 Please correct me if I'm wrong.

Please make sure that your PR meets the following requirements:

- [* ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [* ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [* ] All new functionality is tested
- [* ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [* ] Pull Request contains link to the JIRA issue
- [* ] Pull Request contains link to any dependent or related Pull Request
- [* ] Pull Request contains description of the issue
- [* ] Pull Request does not include fixes for issues other than the main ticket
- [* ] Annotate your PR with the label `safe to test` in order to run the end to end CI pipeline
