### PR TITLE
MGDOBR-264 - cleanup created resource if test fails

### DIFF
--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/common/BridgeCommon.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/common/BridgeCommon.java
@@ -6,6 +6,7 @@ import com.redhat.service.bridge.infra.api.APIConstants;
 import com.redhat.service.bridge.manager.api.models.requests.BridgeRequest;
 import com.redhat.service.bridge.manager.api.models.responses.BridgeListResponse;
 import com.redhat.service.bridge.manager.api.models.responses.BridgeResponse;
+import com.redhat.service.bridge.manager.api.models.responses.ProcessorListResponse;
 import com.redhat.service.bridge.manager.api.models.responses.ProcessorResponse;
 
 import io.restassured.response.Response;
@@ -68,5 +69,10 @@ public class BridgeCommon {
                 .delete(managerUrl + APIConstants.USER_API_BASE_PATH + bridgeId + "/processors/" + processorId)
                 .then()
                 .statusCode(202);
+    }
+
+    public static ProcessorListResponse listProcessors(String bridgeId) {
+        return jsonRequestWithAuth()
+                .get(managerUrl + APIConstants.USER_API_BASE_PATH + bridgeId + "/processors/").then().extract().as(ProcessorListResponse.class);
     }
 }

--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/End2EndTestITStep.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/End2EndTestITStep.java
@@ -258,7 +258,7 @@ public class End2EndTestITStep {
     public void cleanUp() {
         if (IntStream.range(0, getBridgeList().getItems().size()).anyMatch(b -> getBridgeList().getItems().get(b).getId().equals(bridgeId))) {
             if (listProcessors(bridgeId).getSize() > 0) {
-                deleteProcessor(bridgeId, processorId);
+                IntStream.range(0, listProcessors(bridgeId).getItems().size()).forEach(p -> deleteProcessor(bridgeId, listProcessors(bridgeId).getItems().get(p).getId()));
                 Awaitility.await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(5)).until(() -> listProcessors(bridgeId).getSize() == 0);
                 deleteBridge(bridgeId);
             }

--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/End2EndTestITStep.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/End2EndTestITStep.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.stream.IntStream;
 
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
@@ -256,11 +255,10 @@ public class End2EndTestITStep {
 
     @After
     public void cleanUp() {
-        if (IntStream.range(0, getBridgeList().getItems().size()).anyMatch(b -> getBridgeList().getItems().get(b).getId().equals(bridgeId))) {
+        if (getBridgeList().getItems().stream().anyMatch(b -> b.getId().equals(bridgeId))) {
             if (listProcessors(bridgeId).getSize() > 0) {
-                IntStream.range(0, listProcessors(bridgeId).getItems().size()).forEach(p -> deleteProcessor(bridgeId, listProcessors(bridgeId).getItems().get(p).getId()));
+                listProcessors(bridgeId).getItems().stream().forEach(p -> deleteProcessor(bridgeId, p.getId()));
                 Awaitility.await().atMost(Duration.ofMinutes(2)).pollInterval(Duration.ofSeconds(5)).until(() -> listProcessors(bridgeId).getSize() == 0);
-                deleteBridge(bridgeId);
             }
             deleteBridge(bridgeId);
         }


### PR DESCRIPTION
[MGDOBR-264](https://issues.redhat.com/browse/MGDOBR-264) 

- Added cleanup method which will delete the created resources in tests for each scenarios and as well as if any test fails

- Added listProcessors method to track the associated processor for the bridge before deletion

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Annotate your PR with the label `safe to test` in order to run the end to end CI pipeline
