### PR TITLE
MGDOBR-199 Fix property of kafkaBootstrapServer

### DIFF
--- a/manager/src/main/java/com/redhat/service/bridge/manager/connectors/creation/CreateConnectorWorker.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/connectors/creation/CreateConnectorWorker.java
@@ -29,7 +29,7 @@ public class CreateConnectorWorker extends AbstractConnectorWorker<Connector> {
     @ConfigProperty(name = "managed-connectors.cluster.id")
     String mcClusterId;
 
-    @ConfigProperty(name = "kafka.bootstrap.servers")
+    @ConfigProperty(name = "managed-connectors.kafka.bootstrap.servers")
     String kafkaBootstrapServer;
 
     @ConfigProperty(name = "managed-connectors.kafka.client.id")


### PR DESCRIPTION
[MGDOBR-199](https://issues.redhat.com/browse/MGDOBR-199) 

Local test didn't show the bug as the `manager_run.sh` script sets both the `kafka.bootstrap.servers`  and the `managed-connectors.kafka.bootstrap.servers` to the same value

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

* <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

* <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
