### PR TITLE
MGDOBR-341 - Limit dev-cluster-check to run only on root repository

### DIFF
--- a/.github/workflows/dev-cluster-check.yml
+++ b/.github/workflows/dev-cluster-check.yml
@@ -6,6 +6,7 @@ jobs:
   run-integration-tests:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    if: github.repository == '5733d9e2be6485d52ffa08870cabdee0/sandbox'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
[MGDOBR-341](https://issues.redhat.com/browse/MGDOBR-341) 

Limit "dev-cluster-check" Github workflow to run only on root repository. It will not run on forked repositories. 

Please make sure that your PR meets the following requirements:

- [*] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [*] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [NA] All new functionality is tested
- [*] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [*] Pull Request contains link to the JIRA issue
- [*] Pull Request contains link to any dependent or related Pull Request
- [*] Pull Request contains description of the issue
- [*] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

* <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

* <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
