### PR TITLE
[MGDOBR-351] Adding install script for knative/kafka

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -192,3 +192,13 @@ The script runs forever, on linux machines press `CTRL+C` to stop it (or just se
 With the parameters `--manager`, `--keycloak`, `--username` and `--password` you can configure the script so to target any environment (for example the demo environment).
 
 The grafana dashboards in the `grafana` folder are just for development purposes, but it's good to keep them in sync with the dashboards deployed in the demo environment (those dashboards are located at `kustomize/overlays/prod/observability/grafana`).
+
+## Knative
+
+The [knative-installer.sh](bin/knative-installer.sh) script applies Knative Eventing and Knative Eventing Kafka components on the Kubernetes cluster.
+
+Just run it without arguments:
+
+```bash
+./dev/bin/knative-installer.sh
+```

--- a/dev/bin/knative-installer.sh
+++ b/dev/bin/knative-installer.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 knative-setup.sh
+NO_COLOR=${NO_COLOR:-""}
+if [ -z "$NO_COLOR" ]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+# The Knative Core APIs, like Broker or Trigger
+eventing_core_url=https://raw.githubusercontent.com/openshift/knative-eventing/release-v1.1/openshift/release/knative-eventing-ci.yaml
+# Knative Kafka offering: All Kafka centric APIs
+eventing_kafka_url=https://gist.githubusercontent.com/matzew/82280d23baa6cfd6c332c2325f5785c9/raw/848e2d9b36b39c491a60ba24f4ce167201a218ef/knative-kafka.yaml
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+header_text "Knative Eventing Kafka - Installer"
+
+header_text "Initializing Knative Eventing Core APIs"
+kubectl apply --filename $eventing_core_url
+
+header_text "Waiting for Knative Eventing Core to become ready"
+kubectl wait deployment --all --timeout=-1s --for=condition=Available -n knative-eventing
+
+header_text "Initializing Knative Eventing Kafka APIs"
+kubectl apply --filename $eventing_kafka_url
+
+header_text "Patch the deployment to disable Source/Channel..."
+kubectl patch deployment \
+  kafka-controller \
+  --namespace knative-eventing \
+  --type='json' \
+  -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args", "value": [
+  "--disable-controllers=source-controller,channel-controller"
+]}]'
+
+header_text "Waiting for Knative Eventing Kafka to become ready"
+kubectl wait deployment --all --timeout=-1s --for=condition=Available -n knative-eventing
+
+header_text "Registering 'Kafka' as default Knative Eventing Broker"
+cat <<-EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-br-defaults
+  namespace: knative-eventing
+data:
+  default-br-config: |
+    clusterDefault:
+      brokerClass: Kafka
+      apiVersion: v1
+      kind: ConfigMap
+      name: kafka-broker-config
+      namespace: knative-eventing
+EOF

--- a/dev/bin/knative-kafka-broker-demo.sh
+++ b/dev/bin/knative-kafka-broker-demo.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+########
+# Full setup of test Managed Kafka instance and service accounts.
+# It is idempotent and can be run multiple times.
+#
+# Env vars:
+# - MANAGED_KAFKA_INSTANCE_NAME: set the managed kafka instance name (required)
+########
+
+SCRIPT_DIR_PATH=`dirname "${BASH_SOURCE[0]}"`
+
+. "${SCRIPT_DIR_PATH}/configure.sh" kafka
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+function create_kafka_secret(){
+  header_text "Create a secret for $MANAGED_KAFKA_INSTANCE_NAME Knative Kafka Broker auth against RHOSAK"
+
+  mc_client_id=$( getManagedKafkaMcSAClientId ) || die "can't find mc json credentials. Run kafka-setup.sh to configure it."
+  mc_client_secret=$( getManagedKafkaMcSAClientSecret ) || die "can't find mc json credentials. Run kafka-setup.sh to configure it."
+
+  kubectl create secret --namespace default generic $MANAGED_KAFKA_INSTANCE_NAME \
+    --from-literal=protocol=SASL_SSL \
+    --from-literal=sasl.mechanism=PLAIN \
+    --from-literal=user="${mc_client_id}" \
+    --from-literal=password="${mc_client_secret}"
+}
+
+function create_config_map(){
+  header_text "Create a ConfigMap for $MANAGED_KAFKA_INSTANCE_NAME Knative Kafka Broker"
+
+bootstrap_server_host=$( getManagedKafkaBootstrapServerHost ) || die "can't find instance json credentials. Run kafka-setup.sh to configure it."
+
+  cat <<EOF | oc apply -f - || return $?
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: $MANAGED_KAFKA_INSTANCE_NAME-config
+data:
+  default.topic.partitions: "10"
+  default.topic.replication.factor: "3"
+  bootstrap.servers: ${bootstrap_server_host}
+  auth.secret.ref.name: ${MANAGED_KAFKA_INSTANCE_NAME}
+EOF
+}
+
+function create_broker(){
+  header_text "Create the $MANAGED_KAFKA_INSTANCE_NAME Knative Kafka Broker"
+
+  cat <<EOF | oc apply -f - || return $?
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: Kafka
+  name: $MANAGED_KAFKA_INSTANCE_NAME
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: $MANAGED_KAFKA_INSTANCE_NAME-config
+EOF
+}
+
+function setup_kafka(){
+  create_kafka_secret
+  create_config_map
+  create_broker
+}
+
+header_text "Starting to prepare for Kafka Broker for $MANAGED_KAFKA_INSTANCE_NAME"
+setup_kafka


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

[MGDOBR-351](https://issues.redhat.com/browse/MGDOBR-351) 

Adding a minikube install for upstream Knative:

- [X] Knative Eventing Core APIs
- [X] Knative Kafka Broker implementation runtime

Below are a few links about Knative:
* [Knative Eventing](https://knative.dev/docs/eventing/)
* [Knative Broker API](https://knative.dev/docs/eventing/broker/)
* [Kafka-based Broker impl](https://knative.dev/docs/eventing/broker/kafka-broker/) 