### PR TITLE
Fix unavailable Ingress step for integration tests

### DIFF
--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/IngressSteps.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/IngressSteps.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
 
 import com.redhat.service.bridge.integration.tests.common.BridgeUtils;
 import com.redhat.service.bridge.integration.tests.context.TestContext;
@@ -43,7 +44,7 @@ public class IngressSteps {
         Awaitility.await().atMost(Duration.ofMinutes(timeoutMinutes)).pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(() -> IngressResource.optionsJsonEmptyEventResponse(context.getManagerToken(), endpoint)
                         .then()
-                        .statusCode(404));
+                        .statusCode(Matchers.anyOf(Matchers.is(404), Matchers.is(503))));
     }
 
     @Then("^send a cloud event to the Ingress of the Bridge \"([^\"]*)\":$")


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

Extended HTTP response code to check response produced by OpenShift route (HTTP 503).

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

* <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

* <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
