### PR TITLE
MGDOBR-410 Deletion of Bridge shouldn't fail when Topic is already deleted

### DIFF
--- a/manager/src/main/java/com/redhat/service/bridge/manager/RhoasServiceImpl.java
+++ b/manager/src/main/java/com/redhat/service/bridge/manager/RhoasServiceImpl.java
@@ -61,7 +61,6 @@ public class RhoasServiceImpl implements RhoasService {
                     .onFailure().retry().withJitter(rhoasJitter).withBackOff(Duration.parse(rhoasBackoff)).atMost(rhoasMaxRetries)
                     .await().atMost(Duration.ofSeconds(rhoasTimeout));
         } catch (CompletionException e) {
-
             throw new InternalPlatformException(deleteFailureErrorMessageFor(topicName), e);
         } catch (TimeoutException e) {
             throw new InternalPlatformException(deleteTimeoutErrorMessageFor(topicName), e);

--- a/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/RhoasClientImpl.java
+++ b/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/RhoasClientImpl.java
@@ -5,6 +5,10 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.openshift.cloud.api.kas.auth.models.AclBinding;
 import com.openshift.cloud.api.kas.auth.models.AclOperation;
 import com.openshift.cloud.api.kas.auth.models.AclPatternType;
@@ -16,11 +20,9 @@ import com.openshift.cloud.api.kas.models.ServiceAccount;
 import com.openshift.cloud.api.kas.models.ServiceAccountRequest;
 import com.redhat.service.bridge.rhoas.exceptions.AppServicesException;
 import com.redhat.service.bridge.rhoas.exceptions.RhoasClientException;
+
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
-import org.apache.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RhoasClientImpl implements RhoasClient {
 

--- a/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/RhoasClientImpl.java
+++ b/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/RhoasClientImpl.java
@@ -5,9 +5,6 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.openshift.cloud.api.kas.auth.models.AclBinding;
 import com.openshift.cloud.api.kas.auth.models.AclOperation;
 import com.openshift.cloud.api.kas.auth.models.AclPatternType;
@@ -17,10 +14,13 @@ import com.openshift.cloud.api.kas.auth.models.NewTopicInput;
 import com.openshift.cloud.api.kas.auth.models.Topic;
 import com.openshift.cloud.api.kas.models.ServiceAccount;
 import com.openshift.cloud.api.kas.models.ServiceAccountRequest;
+import com.redhat.service.bridge.rhoas.exceptions.AppServicesException;
 import com.redhat.service.bridge.rhoas.exceptions.RhoasClientException;
-
 import io.smallrye.mutiny.CompositeException;
 import io.smallrye.mutiny.Uni;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RhoasClientImpl implements RhoasClient {
 
@@ -73,7 +73,23 @@ public class RhoasClientImpl implements RhoasClient {
     public Uni<Void> deleteTopic(String topicName) {
         return instanceClient.deleteTopic(topicName)
                 .onItem().invoke(t -> LOG.info("Deleted topic '{}'", topicName))
-                .onFailure().transform(f -> logAndWrapFailure("Error when deleting topic " + topicName, f));
+                .onFailure()
+                .recoverWithUni(f -> handleTopicDeleteFailure(topicName, f));
+    }
+
+    private Uni<Void> handleTopicDeleteFailure(String topicName, Throwable f) {
+        if (!(f instanceof AppServicesException)) {
+            RhoasClientException rhoasClientException = logAndWrapFailure("Error when deleting topic " + topicName, f);
+            return Uni.createFrom().failure(rhoasClientException);
+        }
+        AppServicesException exception = (AppServicesException) f;
+        if (exception.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            LOG.info("Topic {} was already deleted", topicName);
+            return Uni.createFrom().voidItem();
+        } else {
+            RhoasClientException rhoasClientException = logAndWrapFailure("Error when deleting topic " + topicName, f);
+            return Uni.createFrom().failure(rhoasClientException);
+        }
     }
 
     @Override

--- a/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/exceptions/AppServicesException.java
+++ b/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/exceptions/AppServicesException.java
@@ -4,12 +4,19 @@ import com.redhat.service.bridge.infra.exceptions.definitions.platform.InternalP
 
 public class AppServicesException extends InternalPlatformException {
 
+    private final int statusCode;
+
     public AppServicesException(String message, com.openshift.cloud.api.kas.auth.invoker.ApiException e) {
         super(String.format("%s (status=%d)", message, e.getCode()), e);
+        statusCode = e.getCode();
     }
 
     public AppServicesException(String message, com.openshift.cloud.api.kas.invoker.ApiException e) {
         super(String.format("%s (status=%d)", message, e.getCode()), e);
+        statusCode = e.getCode();
     }
 
+    public int getStatusCode() {
+        return statusCode;
+    }
 }

--- a/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasClientTestBase.java
+++ b/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasClientTestBase.java
@@ -42,12 +42,12 @@ abstract class RhoasClientTestBase extends RhoasTestBase {
         verifyWireMockServer(expectedPostTopics, expectedPostACLs, expectedDeleteTopics, expectedDeleteACLs);
     }
 
-    protected void testDeleteTopicAndRevokeAccess(RhoasTopicAccessType accessType, boolean expectFalure, int expectedPostTopics, int expectedPostACLs, int expectedDeleteTopics,
+    protected void testDeleteTopicAndRevokeAccess(RhoasTopicAccessType accessType, boolean expectFailure, int expectedPostTopics, int expectedPostACLs, int expectedDeleteTopics,
             int expectedDeleteACLs) {
         UniAssertSubscriber<?> subscriber = rhoasClient.deleteTopicAndRevokeAccess(TEST_TOPIC_NAME, TEST_SERVICE_ACCOUNT_ID, accessType)
                 .subscribe().withSubscriber(UniAssertSubscriber.create());
 
-        if (expectFalure) {
+        if (expectFailure) {
             subscriber.awaitFailure(Duration.ofSeconds(TIMEOUT_SECONDS));
         } else {
             subscriber.awaitItem(Duration.ofSeconds(TIMEOUT_SECONDS));

--- a/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasClientWithBrokenTopicTest.java
+++ b/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasClientWithBrokenTopicTest.java
@@ -56,4 +56,10 @@ class RhoasClientWithBrokenTopicTest extends RhoasClientTestBase {
         configureMockAPIWithBrokenTopicDeletion();
         testDeleteTopicAndRevokeAccess(RhoasTopicAccessType.CONSUMER_AND_PRODUCER, true, 0, 8, 1, 5);
     }
+
+    @Test
+    void testDeleteTopicAndRevokeAccessConsumerAndProducerWithAlreadyDeletedTopic() {
+        configureMockAPIWithAlreadyDeletedTopic();
+        testDeleteTopicAndRevokeAccess(RhoasTopicAccessType.CONSUMER_AND_PRODUCER, false, 0, 0, 1, 5);
+    }
 }

--- a/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasTestBase.java
+++ b/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasTestBase.java
@@ -43,6 +43,11 @@ abstract class RhoasTestBase {
         kafkaInstanceConfigurator.configureWithBrokenTopicDeletion(wireMockServer);
     }
 
+    protected void configureMockAPIWithAlreadyDeletedTopic() {
+        kafkaMgmtConfigurator.configureWithAllWorking(wireMockServer);
+        kafkaInstanceConfigurator.configureWithAlreadyDeletedTopic(wireMockServer);
+    }
+
     protected void configureMockAPIWithBrokenServiceAccountCreation() {
         kafkaMgmtConfigurator.configureWithBrokenServiceAccountCreation(wireMockServer);
         kafkaInstanceConfigurator.configureWithAllWorking(wireMockServer);

--- a/test-utils/src/main/java/com/redhat/service/bridge/test/rhoas/KafkaInstanceAdminMockServerConfigurator.java
+++ b/test-utils/src/main/java/com/redhat/service/bridge/test/rhoas/KafkaInstanceAdminMockServerConfigurator.java
@@ -52,6 +52,14 @@ public class KafkaInstanceAdminMockServerConfigurator extends AbstractApiMockSer
         server.stubFor(authDelete("/acls?.*").willReturn(responseWithDeletedACL()));
     }
 
+    public void configureWithAlreadyDeletedTopic(WireMockServer server) {
+        server.stubFor(authPost("/topics").willReturn(responseWithStatus(404)));
+        server.stubFor(authDelete("/topics/" + TEST_TOPIC_NAME).willReturn(responseWithStatus(404)));
+
+        server.stubFor(authPost("/acls").willReturn(responseWithStatus(201)));
+        server.stubFor(authDelete("/acls?.*").willReturn(responseWithDeletedACL()));
+    }
+
     public void configureWithBrokenACLCreation(WireMockServer server) {
         server.stubFor(authPost("/topics").willReturn(responseWithCreatedTopic()));
         server.stubFor(authDelete("/topics/" + TEST_TOPIC_NAME).willReturn(responseWithStatus(200)));


### PR DESCRIPTION
[Deletion of Bridge shouldn't fail when Topic is already deleted](https://issues.redhat.com/browse/MGDOBR-410) 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

* <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

* <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
