### PR TITLE
MGDOBR-430: Slack Processor creation is failing with Error when calling Kafka instance TopicsApi (status=409)

### DIFF
--- a/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/IngressSteps.java
+++ b/integration-tests/src/test/java/com/redhat/service/bridge/integration/tests/steps/IngressSteps.java
@@ -12,10 +12,10 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.hamcrest.Matchers;
 
-import com.redhat.service.bridge.integration.tests.common.AwaitilityOnTimeOutHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.redhat.service.bridge.infra.utils.CloudEventUtils;
+import com.redhat.service.bridge.integration.tests.common.AwaitilityOnTimeOutHandler;
 import com.redhat.service.bridge.integration.tests.common.BridgeUtils;
 import com.redhat.service.bridge.integration.tests.context.TestContext;
 import com.redhat.service.bridge.integration.tests.resources.IngressResource;

--- a/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/KafkaInstanceAdminClient.java
+++ b/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/KafkaInstanceAdminClient.java
@@ -12,6 +12,8 @@ public interface KafkaInstanceAdminClient {
 
     Uni<Void> deleteAcl(AclBinding aclBinding);
 
+    Uni<Topic> getTopic(String topicName);
+
     Uni<Topic> createTopic(NewTopicInput newTopicInput);
 
     Uni<Void> deleteTopic(String topicName);

--- a/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/KafkaInstanceAdminClientImpl.java
+++ b/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/KafkaInstanceAdminClientImpl.java
@@ -42,6 +42,11 @@ public class KafkaInstanceAdminClientImpl extends AbstractAppServicesClientImpl 
     }
 
     @Override
+    public Uni<Topic> getTopic(String topicName) {
+        return topicsValueCall(api -> api.getTopic(topicName));
+    }
+
+    @Override
     public Uni<Topic> createTopic(NewTopicInput newTopicInput) {
         return topicsValueCall(api -> api.createTopic(newTopicInput));
     }

--- a/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/RhoasClient.java
+++ b/rhoas-client/src/main/java/com/redhat/service/bridge/rhoas/RhoasClient.java
@@ -13,6 +13,8 @@ public interface RhoasClient {
 
     Uni<Void> deleteServiceAccount(String id);
 
+    Uni<Topic> getTopic(String topicName);
+
     Uni<Topic> createTopic(NewTopicInput newTopicInput);
 
     Uni<Topic> createTopicAndGrantAccess(NewTopicInput newTopicInput, String userId, RhoasTopicAccessType accessType);

--- a/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasClientWithBrokenTopicTest.java
+++ b/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasClientWithBrokenTopicTest.java
@@ -40,6 +40,12 @@ class RhoasClientWithBrokenTopicTest extends RhoasClientTestBase {
     }
 
     @Test
+    void testCreateTopicAndGrantAccessProducerWithAlreadyCreatedTopic() {
+        configureMockAPIWithAlreadyCreatedTopic();
+        testCreateTopicAndGrantAccess(RhoasTopicAccessType.CONSUMER_AND_PRODUCER, false, 1, 8, 0, 0);
+    }
+
+    @Test
     void testDeleteTopicAndRevokeAccessConsumerWithBrokenTopicDeletion() {
         configureMockAPIWithBrokenTopicDeletion();
         testDeleteTopicAndRevokeAccess(RhoasTopicAccessType.CONSUMER, true, 0, 3, 1, 2);

--- a/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasTestBase.java
+++ b/rhoas-client/src/test/java/com/redhat/service/bridge/rhoas/RhoasTestBase.java
@@ -38,6 +38,11 @@ abstract class RhoasTestBase {
         kafkaInstanceConfigurator.configureWithBrokenTopicCreation(wireMockServer);
     }
 
+    protected void configureMockAPIWithAlreadyCreatedTopic() {
+        kafkaMgmtConfigurator.configureWithAllWorking(wireMockServer);
+        kafkaInstanceConfigurator.configureWithAlreadyCreatedTopic(wireMockServer);
+    }
+
     protected void configureMockAPIWithBrokenTopicDeletion() {
         kafkaMgmtConfigurator.configureWithAllWorking(wireMockServer);
         kafkaInstanceConfigurator.configureWithBrokenTopicDeletion(wireMockServer);

--- a/test-utils/src/main/java/com/redhat/service/bridge/test/rhoas/AbstractApiMockServerConfigurator.java
+++ b/test-utils/src/main/java/com/redhat/service/bridge/test/rhoas/AbstractApiMockServerConfigurator.java
@@ -47,6 +47,10 @@ public abstract class AbstractApiMockServerConfigurator {
         return auth(WireMock::post, subPath);
     }
 
+    protected MappingBuilder authGet(String subPath) {
+        return auth(WireMock::get, subPath);
+    }
+
     protected ResponseDefinitionBuilder jsonResponse(Object body) {
         return jsonResponse(body, 200);
     }

--- a/test-utils/src/main/java/com/redhat/service/bridge/test/rhoas/KafkaInstanceAdminMockServerConfigurator.java
+++ b/test-utils/src/main/java/com/redhat/service/bridge/test/rhoas/KafkaInstanceAdminMockServerConfigurator.java
@@ -44,6 +44,15 @@ public class KafkaInstanceAdminMockServerConfigurator extends AbstractApiMockSer
         server.stubFor(authDelete("/acls?.*").willReturn(responseWithDeletedACL()));
     }
 
+    public void configureWithAlreadyCreatedTopic(WireMockServer server) {
+        server.stubFor(authPost("/topics").willReturn(responseWithStatus(409)));
+        server.stubFor(authDelete("/topics/" + TEST_TOPIC_NAME).willReturn(responseWithStatus(409)));
+        server.stubFor(authGet("/topics/" + TEST_TOPIC_NAME).willReturn(responseWithCreatedTopic()));
+
+        server.stubFor(authPost("/acls").willReturn(responseWithStatus(201)));
+        server.stubFor(authDelete("/acls?.*").willReturn(responseWithDeletedACL()));
+    }
+
     public void configureWithBrokenTopicDeletion(WireMockServer server) {
         server.stubFor(authPost("/topics").willReturn(responseWithStatus(500)));
         server.stubFor(authDelete("/topics/" + TEST_TOPIC_NAME).willReturn(responseWithStatus(500)));


### PR DESCRIPTION
[MGDOBR-430](https://issues.redhat.com/browse/MGDOBR-430) 

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config)
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

* <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

* <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
