### PR TITLE
MGDOBR-458 Extend Bridge creation timeout in integration tests

### DIFF
--- a/integration-tests/src/test/resources/features/bridge.feature
+++ b/integration-tests/src/test/resources/features/bridge.feature
@@ -4,7 +4,7 @@ Feature: Bridge tests
     Given authenticate against Manager
     And create a new Bridge "mybridge"
     And the list of Bridge instances is containing the Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
     
     When delete the Bridge "mybridge"
@@ -32,7 +32,7 @@ Feature: Bridge tests
   Scenario: Cannot access Bridge details without authentication
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
 
     When logout of Manager

--- a/integration-tests/src/test/resources/features/ingress.feature
+++ b/integration-tests/src/test/resources/features/ingress.feature
@@ -3,7 +3,7 @@ Feature: Ingress tests
   Background:
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
     And add a Processor to the Bridge "mybridge" with body:
     """

--- a/integration-tests/src/test/resources/features/processor-template.feature
+++ b/integration-tests/src/test/resources/features/processor-template.feature
@@ -3,7 +3,7 @@ Feature: Tests of Processor Transformation template
   Background:
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
 
   Scenario: Transform cloud event to Slack message and send it using WebHook

--- a/integration-tests/src/test/resources/features/processor.feature
+++ b/integration-tests/src/test/resources/features/processor.feature
@@ -3,7 +3,7 @@ Feature: Processor tests
   Scenario: Processor is created, deployed and correctly deleted
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
 
     And add a Processor to the Bridge "mybridge" with body:
@@ -35,7 +35,7 @@ Feature: Processor tests
     Given authenticate against Manager
     
     When create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
     
     Then add a Processor to the Bridge "mybridge" with body is failing with HTTP response code 400:
@@ -48,7 +48,7 @@ Feature: Processor tests
   Scenario: Delete non existing processor
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
 
     When add a fake Processor "myProcessor" to the Bridge "mybridge"
@@ -59,7 +59,7 @@ Feature: Processor tests
     Given authenticate against Manager
     
     When create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
     
     Then add a Processor to the Bridge "mybridge" with body is failing with HTTP response code 400:
@@ -73,7 +73,7 @@ Feature: Processor tests
   Scenario: Cannot access the list of Processors without authentication
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
 
     When logout of Manager
@@ -83,7 +83,7 @@ Feature: Processor tests
   Scenario: Cannot create a processor without authentication
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
 
     When logout of Manager
@@ -104,7 +104,7 @@ Feature: Processor tests
   Scenario: Cannot access processor details without authentication
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
     And the Ingress of Bridge "mybridge" is available within 2 minutes
 
     And add a Processor to the Bridge "mybridge" with body:


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

[MGDOBR-458](https://issues.redhat.com/browse/MGDOBR-458)

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
