### PR TITLE
Enable dev cluster check

### DIFF
--- a/.github/workflows/dev-cluster-check.yml
+++ b/.github/workflows/dev-cluster-check.yml
@@ -1,8 +1,8 @@
 name: Check development cluster
 on:
   workflow_dispatch
-#  schedule:
-#    - cron: '0 0/2 * * *'
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   run-integration-tests:
     timeout-minutes: 30


### PR DESCRIPTION
Enable periodical dev cluster check as it seems that errors were fixed and tests are passing again. https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox/actions/runs/2069804325

I've change the cron to run it only once a day. It seems enough to detect if cluster is in health state.