### PR TITLE
MGDOBR-506: sonar pullrequest specific properties

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,8 +37,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+          PR_BASE: ${{ github.BASE_REF }}
+          PR_BRANCH: ${{ github.HEAD_REF }}
+          PR_KEY: ${{ github.event.number }}
         with:
-          maven-command: -B sonar:sonar -Dsonar.projectKey=5733d9e2be6485d52ffa08870cabdee0_sandbox -Dsonar.organization=5733d9e2be6485d52ffa08870cabdee0 -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN
+          maven-command: |
+            -B sonar:sonar -Dsonar.projectKey=5733d9e2be6485d52ffa08870cabdee0_sandbox \
+            -Dsonar.organization=5733d9e2be6485d52ffa08870cabdee0 \
+            -Dsonar.host.url=https://sonarcloud.io \
+            -Dsonar.login=$SONAR_TOKEN \
+            -Dsonar.pullrequest.key=$PR_KEY \
+            -Dsonar.pullrequest.branch=$PR_BRANCH \
+            -Dsonar.pullrequest.base=$PR_BASE
+
       - name: Publish Test Report
         if: ${{ always() }}
         uses: scacap/action-surefire-report@v1.0.10


### PR DESCRIPTION
[MGDOBR-506](https://issues.redhat.com/browse/MGDOBR-506)

This PR brings pull request sonar analysis available on sonarcloud console - https://sonarcloud.io/project/overview?id=5733d9e2be6485d52ffa08870cabdee0_sandbox

If the results won't be avaiable in github ui, I can investigate more.

In my testing job, we can see:

```
mvn -B sonar:sonar -Dsonar.projectKey=5733d9e2be6485d52ffa08870cabdee0_sandbox \
  -Dsonar.organization=5733d9e2be6485d52ffa08870cabdee0 \
  -Dsonar.host.url=https://sonarcloud.io/ \
  -Dsonar.login=$SONAR_TOKEN \
  -Dsonar.pullrequest.key=$PR_KEY \
  -Dsonar.pullrequest.branch=$PR_BRANCH \
  -Dsonar.pullrequest.base=$PR_BASE
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.14-1/x64
    GITHUB_TOKEN: ***
    SONAR_TOKEN: ***
    PR_BASE: MGDOBR-506
    PR_BRANCH: MGDOBR-506-tmp
    PR_KEY: 4
```

and 
```
70353 [INFO] ANALYSIS SUCCESSFUL, you can find the results at: https://sonarcloud.io/dashboard?id=5733d9e2be6485d52ffa08870cabdee0_sandbox&pullRequest=4
70353 [INFO] Note that you will be able to access the updated dashboard once the server has processed the submitted analysis report
70354 [INFO] More about the report processing at https://sonarcloud.io/api/ce/task?id=AX_94Qm_CCidp96r2zlV
```
For more details see:
https://github.com/jomarko/sandbox/runs/5846800041?check_suite_focus=true
