### PR TITLE
[NO JIRA] E2E log request in case of Processor check fail

### DIFF
--- a/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/steps/ProcessorSteps.java
+++ b/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/steps/ProcessorSteps.java
@@ -151,7 +151,8 @@ public class ProcessorSteps {
                 .conditionEvaluationListener(new AwaitilityOnTimeOutHandler(
                         () -> ProcessorResource
                                 .getProcessorResponse(context.getManagerToken(), bridgeContext.getId(),
-                                        processorId)))
+                                        processorId)
+                                .then().log().all()))
                 .atMost(Duration.ofMinutes(timeoutMinutes))
                 .pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(
@@ -210,7 +211,8 @@ public class ProcessorSteps {
                 .conditionEvaluationListener(new AwaitilityOnTimeOutHandler(
                         () -> ProcessorResource
                                 .getProcessorResponse(context.getManagerToken(), bridgeContext.getId(),
-                                        processorId)))
+                                        processorId)
+                                .then().log().all()))
                 .atMost(Duration.ofMinutes(timeoutMinutes))
                 .pollInterval(Duration.ofSeconds(5))
                 .untilAsserted(


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

Added missing log entries in case Processor related waiting loop fails.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
