### PR TITLE
MGDOBR-613 E2E add a waiting step after Processor update

### DIFF
--- a/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/steps/WaitingSteps.java
+++ b/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/steps/WaitingSteps.java
@@ -1,0 +1,25 @@
+
+package com.redhat.service.smartevents.integration.tests.steps;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+import io.cucumber.java.en.When;
+
+public class WaitingSteps {
+
+    @When("^wait for (\\d+) (second|seconds|minute|minutes)$")
+    public void slackActionTest(int amount, String chronoUnits) throws InterruptedException {
+        ChronoUnit parsedChronoUnits = parseChronoUnits(chronoUnits);
+        TimeUnit.of(parsedChronoUnits).sleep(amount);
+    }
+
+    private ChronoUnit parseChronoUnits(String chronoUnits) {
+        for (ChronoUnit u : ChronoUnit.values()) {
+            if (u.toString().toLowerCase().startsWith(chronoUnits)) {
+                return u;
+            }
+        }
+        throw new RuntimeException("Chrono unit not found: " + chronoUnits);
+    }
+}

--- a/integration-tests/src/test/resources/features/processor-template.feature
+++ b/integration-tests/src/test/resources/features/processor-template.feature
@@ -81,6 +81,8 @@ Feature: Tests of Processor Transformation template
     }
     """
     And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    # Need to wait until original Processor pod is completely terminated, see https://issues.redhat.com/browse/MGDOBR-613
+    And wait for 10 seconds
     And send a cloud event to the Ingress of the Bridge "mybridge":
     """
     {


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

[MGDOBR-613](https://issues.redhat.com/browse/MGDOBR-613)

E2E tests checking update of Processor are failing intermittently.

This is caused by sending a cloud event before Processor to be updated container is fully terminated:
Once updated Processor change its container state to ready and termination of former Processor is initiated then operator returns ready state. However the terminated Processor can still process some events before fully terminated, causing random test fails.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
