### PR TITLE
MGDOBR-645 - Allow E2E tests to use openshift offline token

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -68,12 +68,12 @@ Script has 3 options:
 For remote testing you can execute tests using Maven command:
 
 ```bash
-mvn clean verify -Pcucumber -Devent-bridge.manager.url=<MANAGER_URL> -Dkeycloak.realm.url=<KEYCLOAK_URL> -Dbridge.client.id=<CLIENT_ID> -Dbridge.client.secret=<CLIENT_SECRET>
+export OPENSHIFT_OFFLINE_TOKEN=<openshift-offline-token> # To obtain it, go to https://console.redhat.com/openshift/token
+mvn clean verify -Pcucumber -Devent-bridge.manager.url=<MANAGER_URL> -Dkeycloak.realm.url=<KEYCLOAK_URL> -Dbridge.client.id=<CLIENT_ID>
+# Example:
+# <CLIENT_ID>="cloud-services"
+# <KEYCLOAK_URL>="https://sso.redhat.com/auth/realms/redhat-external"
 ```
-
-Optionally the `keycloak.realm.url`, `bridge.client.id` and `bridge.client.secret` parameters can be omitted by setting `OB_TOKEN` environment variable with valid SSO token.  
-Just a note, the `OB_TOKEN` value has to be the token value itself, without the `Bearer` prefix.  
-
 
 ### Remote system access configuration
 

--- a/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/common/BridgeUtils.java
+++ b/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/common/BridgeUtils.java
@@ -15,19 +15,34 @@ public class BridgeUtils {
     public static final String MANAGER_URL = System.getProperty("event-bridge.manager.url");
     protected static final String CLIENT_ID = System.getProperty("bridge.client.id");
     protected static final String CLIENT_SECRET = System.getProperty("bridge.client.secret");
+    protected static final String OPENSHIFT_OFFLINE_TOKEN = System.getenv("OPENSHIFT_OFFLINE_TOKEN");
 
     protected static String keycloakURL = System.getProperty("keycloak.realm.url");
 
     public static String retrieveBridgeToken() {
-        String env_token = System.getenv("OB_TOKEN");
-        if (env_token != null) {
-            return env_token;
+        if (keycloakURL != null && !keycloakURL.isEmpty() && OPENSHIFT_OFFLINE_TOKEN != null) {
+            return refreshAccessToken();
         } else if (keycloakURL != null && !keycloakURL.isEmpty()) {
             return getAccessToken();
         } else {
             throw new RuntimeException(
                     "Environment variable token and keycloak.realm.url was not defined for token generation.");
         }
+    }
+
+    private static String refreshAccessToken() {
+        if (CLIENT_ID.isEmpty() || OPENSHIFT_OFFLINE_TOKEN.isEmpty()) {
+            throw new RuntimeException("Client_credentials were not defined for token refresh.");
+        }
+        return given().param("grant_type", "refresh_token")
+                .param("client_id", CLIENT_ID)
+                .param("refresh_token", OPENSHIFT_OFFLINE_TOKEN)
+                .contentType("application/x-www-form-urlencoded")
+                .accept(ContentType.JSON)
+                .when()
+                .post(keycloakURL + "/protocol/openid-connect/token")
+                .as(AccessTokenResponse.class)
+                .getToken();
     }
 
     private static String getAccessToken() {


### PR DESCRIPTION
Currently E2E tests use OB_TOKEN for SSO authentication. However, this token expires within 15 minutes. The goal of this Jira is to allow user to use OPENSHIFT_OFFLINE_TOKEN when running E2E tests.

Acceptance Criteria: E2E tests can be run with OPENSHIFT_OFFLINE_TOKEN.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [*] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [*] All new functionality is tested
- [*] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [*] Pull Request contains link to any dependent or related Pull Request
- [*] Pull Request contains description of the issue
- [*] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.

</details>
