### PR TITLE
[no jira] Enable export of junit files

### DIFF
--- a/.github/workflows/dev-cluster-check.yml
+++ b/.github/workflows/dev-cluster-check.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ always() }}
         uses: scacap/action-surefire-report@v1.0.10
         with:
-          skip_publishing: true
+          skip_publishing: false
           check_name: Test Results
           fail_on_test_failures: true
           fail_if_no_tests: false

--- a/.github/workflows/stable-cluster-check.yml
+++ b/.github/workflows/stable-cluster-check.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ always() }}
         uses: scacap/action-surefire-report@v1.0.10
         with:
-          skip_publishing: true
+          skip_publishing: false
           check_name: Test Results
           fail_on_test_failures: true
           fail_if_no_tests: false


### PR DESCRIPTION
Turn on export of junits in dev/stable cluster checks. This will help us with investigation of failures.