### PR TITLE
MGDOBR-669 Removing authentication from Error Catalog API

### DIFF
--- a/manager/src/main/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPI.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPI.java
@@ -36,16 +36,9 @@ import com.redhat.service.smartevents.infra.models.QueryPageInfo;
 import io.quarkus.security.Authenticated;
 
 @Tag(name = "Error Catalog", description = "List and get the error definitions from the error catalog.")
-@SecuritySchemes(value = {
-        @SecurityScheme(securitySchemeName = "bearer",
-                type = SecuritySchemeType.HTTP,
-                scheme = "Bearer")
-})
-@SecurityRequirement(name = "bearer")
 @Path(APIConstants.ERROR_API_BASE_PATH)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-@Authenticated
 public class ErrorsAPI {
 
     @Inject

--- a/manager/src/main/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPI.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPI.java
@@ -14,6 +14,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
 import com.redhat.service.smartevents.infra.api.APIConstants;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorListResponse;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorResponse;
@@ -21,12 +28,6 @@ import com.redhat.service.smartevents.infra.api.models.responses.ListResponse;
 import com.redhat.service.smartevents.infra.exceptions.BridgeError;
 import com.redhat.service.smartevents.infra.exceptions.BridgeErrorService;
 import com.redhat.service.smartevents.infra.models.QueryPageInfo;
-import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 @Tag(name = "Error Catalog", description = "List and get the error definitions from the error catalog.")
 @Path(APIConstants.ERROR_API_BASE_PATH)

--- a/manager/src/main/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPI.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPI.java
@@ -14,17 +14,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
-import org.eclipse.microprofile.openapi.annotations.media.Content;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
-import org.eclipse.microprofile.openapi.annotations.security.SecuritySchemes;
-import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-
 import com.redhat.service.smartevents.infra.api.APIConstants;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorListResponse;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorResponse;
@@ -32,8 +21,12 @@ import com.redhat.service.smartevents.infra.api.models.responses.ListResponse;
 import com.redhat.service.smartevents.infra.exceptions.BridgeError;
 import com.redhat.service.smartevents.infra.exceptions.BridgeErrorService;
 import com.redhat.service.smartevents.infra.models.QueryPageInfo;
-
-import io.quarkus.security.Authenticated;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 @Tag(name = "Error Catalog", description = "List and get the error definitions from the error catalog.")
 @Path(APIConstants.ERROR_API_BASE_PATH)

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPITest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPITest.java
@@ -2,14 +2,16 @@ package com.redhat.service.smartevents.manager.api.user;
 
 import java.util.Collection;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import com.redhat.service.smartevents.infra.api.APIConstants;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorListResponse;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorResponse;
 import com.redhat.service.smartevents.test.exceptions.ExceptionHelper;
+
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPITest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/api/user/ErrorsAPITest.java
@@ -2,18 +2,14 @@ package com.redhat.service.smartevents.manager.api.user;
 
 import java.util.Collection;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import com.redhat.service.smartevents.infra.api.APIConstants;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorListResponse;
 import com.redhat.service.smartevents.infra.api.models.responses.ErrorResponse;
-import com.redhat.service.smartevents.manager.TestConstants;
 import com.redhat.service.smartevents.test.exceptions.ExceptionHelper;
-
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +25,6 @@ class ErrorsAPITest {
     }
 
     @Test
-    @TestSecurity(user = TestConstants.DEFAULT_CUSTOMER_ID)
     void testGetList() {
         ErrorListResponse response = given().contentType(ContentType.JSON).when().get(APIConstants.ERROR_API_BASE_PATH).as(ErrorListResponse.class);
         assertThat(exceptionClasses).hasSize((int) response.getTotal());

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -477,8 +477,6 @@ paths:
           description: Internal error.
           content:
             application/json: {}
-      security:
-      - bearer: []
   /api/v1/errors/{id}:
     get:
       tags:
@@ -510,8 +508,6 @@ paths:
           description: Internal error.
           content:
             application/json: {}
-      security:
-      - bearer: []
   /api/v1/shard/bridges:
     get:
       tags:


### PR DESCRIPTION
[MGDOBR-669](https://issues.redhat.com/browse/MGDOBR-669)

In order to implement MGDOBR-669 we are removing authentication from `/error/*` endpoints like has been done in Kafka and Service Registry (you can refer to https://github.com/redhat-developer/app-services-sdk-js/blob/main/scripts/errors/fetch-errors.sh)

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
