### PR TITLE
[MGDOBR-778] Kustomize overrides all the namespaces - fix knative and istio

### DIFF
--- a/kustomize/base-openshift/shard/knative/broker-network-policy.yaml
+++ b/kustomize/base-openshift/shard/knative/broker-network-policy.yaml
@@ -3,7 +3,8 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: kafka-broker-receiver
-  namespace: knative-eventing
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: knative-eventing
   labels:
     app: kafka-broker-receiver
 spec:

--- a/kustomize/base-openshift/shard/knative/knative-eventing.yaml
+++ b/kustomize/base-openshift/shard/knative/knative-eventing.yaml
@@ -2,5 +2,6 @@ apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing
 metadata:
   name: knative-eventing
-  namespace: knative-eventing
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: knative-eventing
 spec: {}

--- a/kustomize/base-openshift/shard/knative/knative-kafka.yaml
+++ b/kustomize/base-openshift/shard/knative/knative-kafka.yaml
@@ -2,7 +2,8 @@ apiVersion: operator.serverless.openshift.io/v1alpha1
 kind: KnativeKafka
 metadata:
   name: knative-kafka
-  namespace: knative-eventing
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: knative-eventing
 spec:
   broker:
     enabled: true

--- a/kustomize/base-openshift/shard/knative/webhook-network-policy.yaml
+++ b/kustomize/base-openshift/shard/knative/webhook-network-policy.yaml
@@ -3,7 +3,8 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: eventing-webhook
-  namespace: knative-eventing
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: knative-eventing
   labels:
     app: eventing-webhook
 spec:

--- a/kustomize/base-openshift/shard/service-mesh/gateway.yaml
+++ b/kustomize/base-openshift/shard/service-mesh/gateway.yaml
@@ -2,7 +2,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: broker-gateway
-  namespace: knative-eventing
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: knative-eventing
 spec:
   selector:
     istio: ingressgateway

--- a/kustomize/base-openshift/shard/service-mesh/jwt-request-authentication.yaml
+++ b/kustomize/base-openshift/shard/service-mesh/jwt-request-authentication.yaml
@@ -2,7 +2,8 @@ apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
 metadata:
   name: jwt-rh-sso
-  namespace: istio-system
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: istio-system
 spec:
   jwtRules:
     - issuer: 'https://sso.redhat.com/auth/realms/redhat-external'

--- a/kustomize/base-openshift/shard/service-mesh/service-mesh-control-plane.yaml
+++ b/kustomize/base-openshift/shard/service-mesh/service-mesh-control-plane.yaml
@@ -2,7 +2,8 @@ apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
-  namespace: istio-system
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: istio-system
 spec:
   addons:
     grafana:

--- a/kustomize/base-openshift/shard/service-mesh/service-mesh-member-roll.yaml
+++ b/kustomize/base-openshift/shard/service-mesh/service-mesh-member-roll.yaml
@@ -2,7 +2,8 @@ apiVersion: maistra.io/v1
 kind: ServiceMeshMemberRoll
 metadata:
   name: default
-  namespace: istio-system
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: istio-system
 spec:
   members:
     - knative-eventing

--- a/kustomize/base-openshift/shard/service-mesh/virtual-service-kafka-broker.yaml
+++ b/kustomize/base-openshift/shard/service-mesh/virtual-service-kafka-broker.yaml
@@ -2,7 +2,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: broker-virtual-service
-  namespace: knative-eventing
+#  Due to https://github.com/kubernetes-sigs/kustomize/issues/880 we have to override it in overlays/<ENV>/kustomization.yaml
+#  namespace: knative-eventing
 spec:
   gateways:
     - broker-gateway

--- a/kustomize/overlays/dev/kustomization.yaml
+++ b/kustomize/overlays/dev/kustomization.yaml
@@ -1,6 +1,66 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: event-bridge-prod
 resources:
 - ../../base-openshift
 - secrets
 - observability
 - shard
+patchesJson6902:
+  # due to the issue https://github.com/kubernetes-sigs/kustomize/issues/880 we have to patch all the resources here
+  # resources in /kustomize/base-openshift/shard/knative/
+  - target:
+      group: ""
+      version: v1
+      kind: NetworkPolicy
+      name: kafka-broker-receiver
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1alpha1
+      kind: KnativeEventing
+      name: knative-eventing
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1alpha1
+      kind: KnativeKafka
+      name: knative-kafka
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1
+      kind: NetworkPolicy
+      name: eventing-webhook
+    path: patch-with-knative-eventing-namespace.yaml
+  # resources in /kustomize/base-openshift/shard/service-mesh/
+  - target:
+      group: ""
+      version: v1alpha3
+      kind: Gateway
+      name: broker-gateway
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1beta1
+      kind: RequestAuthentication
+      name: jwt-rh-sso
+    path: patch-with-istio-system-namespace.yaml
+  - target:
+      group: ""
+      version: v2
+      kind: ServiceMeshControlPlane
+      name: basic
+    path: patch-with-istio-system-namespace.yaml
+  - target:
+      group: ""
+      version: v1
+      kind: ServiceMeshMemberRoll
+      name: default
+    path: patch-with-istio-system-namespace.yaml
+  - target:
+      group: ""
+      version: v1alpha3
+      kind: VirtualService
+      name: broker-virtual-service
+    path: patch-with-knative-eventing-namespace.yaml

--- a/kustomize/overlays/dev/patch-with-istio-system-namespace.yaml
+++ b/kustomize/overlays/dev/patch-with-istio-system-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: istio-system

--- a/kustomize/overlays/dev/patch-with-knative-eventing-namespace.yaml
+++ b/kustomize/overlays/dev/patch-with-knative-eventing-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: knative-eventing

--- a/kustomize/overlays/stable/kustomization.yaml
+++ b/kustomize/overlays/stable/kustomization.yaml
@@ -1,6 +1,66 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 namespace: event-bridge-stable
 resources:
 - ../../base-openshift
 - secrets
 - observability
 - shard
+patchesJson6902:
+  # due to the issue https://github.com/kubernetes-sigs/kustomize/issues/880 we have to patch all the resources here
+  # resources in /kustomize/base-openshift/shard/knative/
+  - target:
+      group: ""
+      version: v1
+      kind: NetworkPolicy
+      name: kafka-broker-receiver
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1alpha1
+      kind: KnativeEventing
+      name: knative-eventing
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1alpha1
+      kind: KnativeKafka
+      name: knative-kafka
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1
+      kind: NetworkPolicy
+      name: eventing-webhook
+    path: patch-with-knative-eventing-namespace.yaml
+  # resources in /kustomize/base-openshift/shard/service-mesh/
+  - target:
+      group: ""
+      version: v1alpha3
+      kind: Gateway
+      name: broker-gateway
+    path: patch-with-knative-eventing-namespace.yaml
+  - target:
+      group: ""
+      version: v1beta1
+      kind: RequestAuthentication
+      name: jwt-rh-sso
+    path: patch-with-istio-system-namespace.yaml
+  - target:
+      group: ""
+      version: v2
+      kind: ServiceMeshControlPlane
+      name: basic
+    path: patch-with-istio-system-namespace.yaml
+  - target:
+      group: ""
+      version: v1
+      kind: ServiceMeshMemberRoll
+      name: default
+    path: patch-with-istio-system-namespace.yaml
+  - target:
+      group: ""
+      version: v1alpha3
+      kind: VirtualService
+      name: broker-virtual-service
+    path: patch-with-knative-eventing-namespace.yaml

--- a/kustomize/overlays/stable/patch-with-istio-system-namespace.yaml
+++ b/kustomize/overlays/stable/patch-with-istio-system-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: istio-system

--- a/kustomize/overlays/stable/patch-with-knative-eventing-namespace.yaml
+++ b/kustomize/overlays/stable/patch-with-knative-eventing-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: knative-eventing


### PR DESCRIPTION
[MGDOBR-778](https://issues.redhat.com/browse/MGDOBR-778)

I know it's not ideal, but many others have the same issue https://github.com/kubernetes-sigs/kustomize/issues/880

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
