### PR TITLE
MGDOBR-534: add istioctl to required tools in dev scripts

### DIFF
--- a/dev/bin/configure.sh
+++ b/dev/bin/configure.sh
@@ -24,6 +24,7 @@ set -e
 # list of required tools
 required_tools="
 docker-compose
+istioctl
 jq
 kubectl
 kustomize


### PR DESCRIPTION
[MGDOBR-534](https://issues.redhat.com/browse/MGDOBR-534)

`istioctl` is now a required tool by our dev scripts. This PR adds it to the preliminary check so that the script fails if it's not installed.