### PR TITLE
Linting For OpenAPI

### DIFF
--- a/.github/actions/validate_api.yaml
+++ b/.github/actions/validate_api.yaml
@@ -2,7 +2,7 @@ name: Validate API
 
 on:
   pull_request:
-    branches: [ main, api-test ]
+    branches: [ main, linting]
 
 jobs:
   build:

--- a/.github/actions/validate_api.yaml
+++ b/.github/actions/validate_api.yaml
@@ -2,7 +2,7 @@ name: Validate API
 
 on:
   pull_request:
-    branches: [ main, linting]
+    branches: [ main]
 
 jobs:
   build:

--- a/.github/actions/validate_api.yaml
+++ b/.github/actions/validate_api.yaml
@@ -1,0 +1,19 @@
+name: Validate API
+
+on:
+  pull_request:
+    branches: [ main, api-test ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 15.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 15.x
+      - run: npx @stoplight/spectral@5.9.0 lint ./openapi/rhose-api.yaml
+ 

--- a/spectral.yaml
+++ b/spectral.yaml
@@ -1,0 +1,1 @@
+extends: '@rhoas/spectral-ruleset'


### PR DESCRIPTION
## Motivation

Add example for the job that validates API for correctness

## Context

http://api.appservices.tech/ defines OpenAPI standards that your team can follow to build Managed Services Control Plane APIs. We use spectral ruleset to check those rules. We will add validation into github actions once we get initial API validated and onboarded into sdk. 

## Example of objects and OpenAPI annotations to use to meet standards

This API meets all our standards
https://github.com/bf2fc6cc711aee1a0c2a/kafka-admin-api/pull/200

Some of the changes that were made can be copy pasted to your project etc.
Another good example of the Java/Quarkus project that follows the standard would be SRS fleet manager:

https://github.com/bf2fc6cc711aee1a0c2a/srs-fleet-manager/blob/main/core/src/main/resources/srs-fleet-manager.json#L546-L583

## How I can run this locally

http://api.appservices.tech/spectral/
