### PR TITLE
Fix sed used in istio script to work on BSD (macOS) 

### DIFF
--- a/dev/bin/minikube-start.sh
+++ b/dev/bin/minikube-start.sh
@@ -49,10 +49,10 @@ if [ "${disable_extra_components}" != 'true' ]; then
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.9.0/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
   . "${SCRIPT_DIR_PATH}/knative-installer.sh"
   yes | istioctl manifest apply --set profile=default --set values.gateways.istio-ingressgateway.type="ClusterIP"
-  sed -i -E "s|<REPLACE_WITH_MINIKUBE_IP>|$(minikube -p "${MINIKUBE_PROFILE}" ip)|" ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/gateway.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/virtual-service-kafka-broker.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml
+  cat ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml | sed -E "s|<REPLACE_WITH_MINIKUBE_IP>|$(minikube -p "${MINIKUBE_PROFILE}" ip)|" | kubectl apply -f -
 fi
 
 set +x

--- a/dev/bin/minikube-start.sh
+++ b/dev/bin/minikube-start.sh
@@ -49,7 +49,7 @@ if [ "${disable_extra_components}" != 'true' ]; then
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.9.0/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
   . "${SCRIPT_DIR_PATH}/knative-installer.sh"
   istioctl manifest apply --set profile=default --set values.gateways.istio-ingressgateway.type="ClusterIP"
-  sed -i -E "s|(.*http://).*(:30007.*)|\1$(minikube -p "${MINIKUBE_PROFILE}" ip)\2|" ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml
+  sed -i -E "s|\(.*http://\).*\(:30007.*\)|\1$(minikube -p "${MINIKUBE_PROFILE}" ip)\2|" ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/gateway.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/virtual-service-kafka-broker.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml

--- a/dev/bin/minikube-start.sh
+++ b/dev/bin/minikube-start.sh
@@ -49,7 +49,7 @@ if [ "${disable_extra_components}" != 'true' ]; then
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.9.0/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
   . "${SCRIPT_DIR_PATH}/knative-installer.sh"
   istioctl manifest apply --set profile=default --set values.gateways.istio-ingressgateway.type="ClusterIP"
-  sed -i -E "s|\(.*http://\).*\(:30007.*\)|\1$(minikube -p "${MINIKUBE_PROFILE}" ip)\2|" ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml
+  sed -i -E "s|<REPLACE_WITH_MINIKUBE_IP>|$(minikube -p "${MINIKUBE_PROFILE}" ip)|" ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/gateway.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/virtual-service-kafka-broker.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml

--- a/dev/bin/minikube-start.sh
+++ b/dev/bin/minikube-start.sh
@@ -48,7 +48,7 @@ if [ "${disable_extra_components}" != 'true' ]; then
   sleep 5
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/v0.9.0/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
   . "${SCRIPT_DIR_PATH}/knative-installer.sh"
-  istioctl manifest apply --set profile=default --set values.gateways.istio-ingressgateway.type="ClusterIP"
+  yes | istioctl manifest apply --set profile=default --set values.gateways.istio-ingressgateway.type="ClusterIP"
   sed -i -E "s|<REPLACE_WITH_MINIKUBE_IP>|$(minikube -p "${MINIKUBE_PROFILE}" ip)|" ${KUSTOMIZE_DIR}/overlays/minikube/istio/jwt-request-authentication.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/gateway.yaml
   kubectl apply -f ${KUSTOMIZE_DIR}/overlays/minikube/istio/virtual-service-kafka-broker.yaml


### PR DESCRIPTION
This is needed as the current version doesn't work on BSD and always modifies the `jwt-request-authentication.yaml` file, also creating a wrong backup file in the working directory

<img width="389" alt="Screenshot 2022-06-14 at 10 41 32" src="https://user-images.githubusercontent.com/454752/173540366-a1a3b14f-2977-40a8-8ae1-31b9fef4e0ac.png">


## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
