### PR TITLE
[DRAFT] MGDOBR-441: Shard may never delete resources if it crashes after sending DELETING status call

### DIFF
--- a/integration-tests/src/test/resources/features/action-sendtobridge.feature
+++ b/integration-tests/src/test/resources/features/action-sendtobridge.feature
@@ -7,11 +7,11 @@ Feature: SendToBridge Action tests
     Given create a new Bridge "bridge1"
     And create a new Bridge "bridge2"
 
-    And the Bridge "bridge1" is existing with status "ready" within 4 minutes
-    And the Bridge "bridge2" is existing with status "ready" within 4 minutes
+    And the Bridge "bridge1" is existing with status "ready" within 5 minutes
+    And the Bridge "bridge2" is existing with status "ready" within 5 minutes
 
-    And the Ingress of Bridge "bridge1" is available within 2 minutes
-    And the Ingress of Bridge "bridge2" is available within 2 minutes
+    And the Ingress of Bridge "bridge1" is available within 3 minutes
+    And the Ingress of Bridge "bridge2" is available within 3 minutes
 
     And add a Processor to the Bridge "bridge1" with body:
     """
@@ -25,7 +25,7 @@ Feature: SendToBridge Action tests
       }
     }
     """
-    And the Processor "sendToBridgeWithBridgeIdProcessor" of the Bridge "bridge1" is existing with status "ready" within 3 minutes
+    And the Processor "sendToBridgeWithBridgeIdProcessor" of the Bridge "bridge1" is existing with status "ready" within 5 minutes
     And the Processor "sendToBridgeWithBridgeIdProcessor" of the Bridge "bridge1" has action of type "send_to_bridge_sink_0.1" and parameters:
       | bridgeId | ${bridge.bridge2.id} |
 
@@ -42,7 +42,7 @@ Feature: SendToBridge Action tests
       "transformationTemplate" : "{ \"text\": \"hello {data.name} by {id}\" }"
     }
     """
-    And the Processor "webhookProcessor" of the Bridge "bridge2" is existing with status "ready" within 3 minutes
+    And the Processor "webhookProcessor" of the Bridge "bridge2" is existing with status "ready" within 5 minutes
     And the Processor "webhookProcessor" of the Bridge "bridge2" has action of type "webhook_sink_0.1" and parameters:
       | endpoint | ${env.slack.webhook.url} |
 
@@ -58,5 +58,5 @@ Feature: SendToBridge Action tests
       }
     }
     """
-    
+
     Then Slack channel contains message with text "hello world by ${cloud-event.my-id.id}" within 1 minute

--- a/integration-tests/src/test/resources/features/action-slack.feature
+++ b/integration-tests/src/test/resources/features/action-slack.feature
@@ -3,8 +3,8 @@ Feature: Slack Action tests
   Background:
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
 
   Scenario: Slack Action Processor is created and slack message should be received in the slack channel
     When add a Processor to the Bridge "mybridge" with body:

--- a/integration-tests/src/test/resources/features/action-webhook.feature
+++ b/integration-tests/src/test/resources/features/action-webhook.feature
@@ -4,8 +4,8 @@ Feature: Webhook Action tests
   Scenario: Webhook is correctly called
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
 
     And add a Processor to the Bridge "mybridge" with body:
     """
@@ -21,7 +21,7 @@ Feature: Webhook Action tests
     }
     """
     And the list of Processor instances of the Bridge "mybridge" is containing the Processor "myProcessor"
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
     And the Processor "myProcessor" of the Bridge "mybridge" has action of type "webhook_sink_0.1" and parameters:
       | endpoint | https://webhook.site/${env.webhook.site.uuid} |
 

--- a/integration-tests/src/test/resources/features/bridge.feature
+++ b/integration-tests/src/test/resources/features/bridge.feature
@@ -4,8 +4,8 @@ Feature: Bridge tests
     Given authenticate against Manager
     And create a new Bridge "mybridge"
     And the list of Bridge instances is containing the Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
 
     When delete the Bridge "mybridge"
 

--- a/integration-tests/src/test/resources/features/error-handling.feature
+++ b/integration-tests/src/test/resources/features/error-handling.feature
@@ -15,8 +15,8 @@ Feature: Error handling tests
         }
     }
     """
-    And the Bridge "ehBridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "ehBridge" is available within 2 minutes
+    And the Bridge "ehBridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "ehBridge" is available within 3 minutes
 
     And add a Processor to the Bridge "ehBridge" with body:
     """
@@ -32,7 +32,7 @@ Feature: Error handling tests
     }
     """
     And the list of Processor instances of the Bridge "ehBridge" is containing the Processor "whProcessor"
-    And the Processor "whProcessor" of the Bridge "ehBridge" is existing with status "ready" within 3 minutes
+    And the Processor "whProcessor" of the Bridge "ehBridge" is existing with status "ready" within 5 minutes
     And the Processor "whProcessor" of the Bridge "ehBridge" has action of type "webhook_sink_0.1" and parameters:
       | endpoint | https://example.com/dummy-webhook |
 

--- a/integration-tests/src/test/resources/features/ingress.feature
+++ b/integration-tests/src/test/resources/features/ingress.feature
@@ -3,8 +3,8 @@ Feature: Ingress tests
   Background:
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
     And add a Processor to the Bridge "mybridge" with body:
     """
     {
@@ -17,7 +17,7 @@ Feature: Ingress tests
       }
     }
     """
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
 
   Scenario: Send Cloud Event
     When send a cloud event to the Ingress of the Bridge "mybridge":

--- a/integration-tests/src/test/resources/features/processor-filter.feature
+++ b/integration-tests/src/test/resources/features/processor-filter.feature
@@ -3,8 +3,8 @@ Feature: Tests of Processor Filter update
   Background:
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
 
   Scenario: Processor filter is updated
     Given add a Processor to the Bridge "mybridge" with body:
@@ -26,7 +26,7 @@ Feature: Tests of Processor Filter update
       ]
     }
     """
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
 
     When update the Processor "myProcessor" of the Bridge "mybridge" with body:
     """
@@ -58,7 +58,7 @@ Feature: Tests of Processor Filter update
       ]
     }
     """
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
     # Need to wait until original Processor pod is completely terminated, see https://issues.redhat.com/browse/MGDOBR-613
     And wait for 10 seconds
     And send a cloud event to the Ingress of the Bridge "mybridge":
@@ -112,7 +112,7 @@ Feature: Tests of Processor Filter update
 
     }
     """
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
 
 
     When send a cloud event to the Ingress of the Bridge "mybridge":

--- a/integration-tests/src/test/resources/features/processor-template.feature
+++ b/integration-tests/src/test/resources/features/processor-template.feature
@@ -3,8 +3,8 @@ Feature: Tests of Processor Transformation template
   Background:
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
 
 
   Scenario: Transform cloud event to Slack message and send it using WebHook
@@ -21,7 +21,7 @@ Feature: Tests of Processor Transformation template
       "transformationTemplate" : "{\"text\": \"hello {data.name} by {id}\"}"
     }
     """
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
     And send a cloud event to the Ingress of the Bridge "mybridge":
     """
     {
@@ -34,7 +34,7 @@ Feature: Tests of Processor Transformation template
       }
     }
     """
-    
+
     Then Slack channel contains message with text "hello world by ${cloud-event.my-id.id}" within 1 minute
 
 
@@ -52,7 +52,7 @@ Feature: Tests of Processor Transformation template
       "transformationTemplate" : "{\"text\": \"hello {data.name} by {id}\"}"
     }
     """
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
     And send a cloud event to the Ingress of the Bridge "mybridge":
     """
     {
@@ -80,7 +80,7 @@ Feature: Tests of Processor Transformation template
       "transformationTemplate" : "{\"text\": \"hello {data.name} by updated template {id}\"}"
     }
     """
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
     # Need to wait until original Processor pod is completely terminated, see https://issues.redhat.com/browse/MGDOBR-613
     And wait for 10 seconds
     And send a cloud event to the Ingress of the Bridge "mybridge":

--- a/integration-tests/src/test/resources/features/processor.feature
+++ b/integration-tests/src/test/resources/features/processor.feature
@@ -3,8 +3,8 @@ Feature: Processor tests
   Scenario: Processor is created, deployed and correctly deleted
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
 
     And add a Processor to the Bridge "mybridge" with body:
     """
@@ -19,7 +19,7 @@ Feature: Processor tests
     }
     """
     And the list of Processor instances of the Bridge "mybridge" is containing the Processor "myProcessor"
-    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 3 minutes
+    And the Processor "myProcessor" of the Bridge "mybridge" is existing with status "ready" within 5 minutes
     And the Processor "myProcessor" of the Bridge "mybridge" has action of type "webhook_sink_0.1" and parameters:
       | endpoint | https://webhook.site/${env.webhook.site.uuid} |
 

--- a/integration-tests/src/test/resources/features/source-slack.feature
+++ b/integration-tests/src/test/resources/features/source-slack.feature
@@ -3,8 +3,8 @@ Feature: Slack Source tests
   Background:
     Given authenticate against Manager
     And create a new Bridge "mybridge"
-    And the Bridge "mybridge" is existing with status "ready" within 4 minutes
-    And the Ingress of Bridge "mybridge" is available within 2 minutes
+    And the Bridge "mybridge" is existing with status "ready" within 5 minutes
+    And the Ingress of Bridge "mybridge" is available within 3 minutes
 
   @slacksource
   Scenario: Slack Source Processor is created and slack message as source should result into other generated slack message

--- a/manager/src/main/java/com/redhat/service/smartevents/manager/models/Bridge.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/models/Bridge.java
@@ -23,7 +23,11 @@ import com.redhat.service.smartevents.infra.models.bridges.BridgeDefinition;
                         "( " +
                         "  (status='PREPARING' and dependencyStatus='READY') " +
                         "  or " +
+                        "  (status='PROVISIONING' and dependencyStatus='READY') " +
+                        "  or " +
                         "  (status='DEPROVISION' and dependencyStatus='DELETED') " +
+                        "  or " +
+                        "  (status='DELETING' and dependencyStatus='DELETED') " +
                         ")"),
         @NamedQuery(name = "BRIDGE.findByNameAndCustomerId",
                 query = "from Bridge where name=:name and customer_id=:customerId"),

--- a/manager/src/main/java/com/redhat/service/smartevents/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/models/Processor.java
@@ -44,7 +44,11 @@ import io.quarkiverse.hibernate.types.json.JsonTypes;
                         "    (" +
                         "      (p.status='PREPARING' and p.dependencyStatus='READY') " +
                         "      or " +
+                        "      (p.status='PROVISIONING' and p.dependencyStatus='READY') " +
+                        "      or " +
                         "      (p.status='DEPROVISION' and p.dependencyStatus='DELETED') " +
+                        "      or " +
+                        "      (p.status='DELETING' and p.dependencyStatus='DELETED') " +
                         "    )" +
                         "  )" +
                         ") or (" +

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/BridgesServiceTest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/BridgesServiceTest.java
@@ -162,7 +162,9 @@ public class BridgesServiceTest {
         bridge.setStatus(PROVISIONING);
         bridgesService.updateBridge(bridgesService.toDTO(bridge));
 
-        assertThat(bridgesService.findByShardIdWithReadyDependencies(SHARD_ID)).isEmpty();
+        // PROVISIONING Bridges are also notified to the Shard Operator.
+        // This ensures Bridges are not dropped should the Shard fail after notifying the Managed a Bridge is being provisioned.
+        assertThat(bridgesService.findByShardIdWithReadyDependencies(SHARD_ID)).hasSize(1);
 
         Bridge retrievedBridge = bridgesService.getBridge(bridge.getId(), DEFAULT_CUSTOMER_ID);
         assertThat(retrievedBridge.getStatus()).isEqualTo(PROVISIONING);

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/api/internal/ShardBridgesSyncAPITest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/api/internal/ShardBridgesSyncAPITest.java
@@ -322,11 +322,13 @@ public class ShardBridgesSyncAPITest {
         bridge.setStatus(PROVISIONING);
         TestUtils.updateBridge(bridge).then().statusCode(200);
 
+        // PROVISIONING Bridges are also notified to the Shard Operator.
+        // This ensures Bridges are not dropped should the Shard fail after notifying the Managed a Bridge is being provisioned.
         await().atMost(5, SECONDS).untilAsserted(() -> {
             bridgesToDeployOrDelete.clear();
             bridgesToDeployOrDelete.addAll(TestUtils.getBridgesToDeployOrDelete().as(new TypeRef<List<BridgeDTO>>() {
             }));
-            assertThat(bridgesToDeployOrDelete).isEmpty();
+            assertThat(bridgesToDeployOrDelete.stream().filter(x -> x.getStatus().equals(PROVISIONING)).count()).isEqualTo(1);
         });
     }
 

--- a/shard-operator-integration-tests/src/test/resources/features/bridgeexecutor-deploy.feature
+++ b/shard-operator-integration-tests/src/test/resources/features/bridgeexecutor-deploy.feature
@@ -24,10 +24,10 @@ Feature: BridgeExecutor deploy and undeploy
       processorName: mybridge-processor
     """
 
-    Then the BridgeExecutor "my-bridge-executor" exists within 1 minute
-    And the Deployment "my-bridge-executor" is ready within 1 minute
-    And the Service "my-bridge-executor" exists within 1 minute
-    And the BridgeExecutor "my-bridge-executor" is in condition "Ready" within 2 minutes
+    Then the BridgeExecutor "my-bridge-executor" exists within 2 minute
+    And the Deployment "my-bridge-executor" is ready within 2 minute
+    And the Service "my-bridge-executor" exists within 2 minute
+    And the BridgeExecutor "my-bridge-executor" is in condition "Ready" within 3 minutes
 
   # Using "dummy" image as real BridgeExecutor image requires Kafka
   Scenario: BridgeExecutor gets deleted

--- a/shard-operator-integration-tests/src/test/resources/features/bridgeingress-deploy.feature
+++ b/shard-operator-integration-tests/src/test/resources/features/bridgeingress-deploy.feature
@@ -18,9 +18,9 @@ Feature: BridgeIngress deploy and undeploy
       customerId: customer
       id: my-bridge-ingress
     """
-     
-     Then the BridgeIngress "my-bridge-ingress" exists within 1 minute
-     And the BridgeIngress "my-bridge-ingress" is in condition "Ready" within 2 minutes
+
+    Then the BridgeIngress "my-bridge-ingress" exists within 2 minute
+    And the BridgeIngress "my-bridge-ingress" is in condition "Ready" within 3 minutes
 
   # Using "dummy" image as real BridgeIngress image requires Kafka
   Scenario: BridgeIngress gets deleted
@@ -40,5 +40,5 @@ Feature: BridgeIngress deploy and undeploy
     And the BridgeIngress "my-deleted-bridge-ingress" is in condition "Ready" within 2 minutes
 
     When delete BridgeIngress "my-deleted-bridge-ingress"
-     
+
     Then the BridgeIngress "my-deleted-bridge-ingress" does not exist within 1 minute

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeExecutorServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeExecutorServiceImpl.java
@@ -97,6 +97,8 @@ public class BridgeExecutorServiceImpl implements BridgeExecutorService {
             return true;
         }
         // Does exist, but it has already entered the Kubernetes reconciliation loop. Don't update it.
+        // The expected definition will always have READY:Unknown set by BridgeExecutor.Builder.build().
+        // READY:False is set by the first iteration through k8s's reconciliation loop.
         if (existing.getStatus()
                 .getConditionByType(ConditionTypeConstants.READY)
                 .filter(c -> c.getStatus() == ConditionStatus.False).isPresent()) {

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeExecutorServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeExecutorServiceImpl.java
@@ -94,6 +94,7 @@ public class BridgeExecutorServiceImpl implements BridgeExecutorService {
     private boolean createOrReplace(BridgeExecutor expected, BridgeExecutor existing) {
         // Does not exist. Create it.
         if (existing == null) {
+            LOGGER.info("Existing BridgeExecutor does not exist. Creating a new instance.");
             return true;
         }
         // Does exist, but it has already entered the Kubernetes reconciliation loop. Don't update it.
@@ -102,6 +103,7 @@ public class BridgeExecutorServiceImpl implements BridgeExecutorService {
         if (existing.getStatus()
                 .getConditionByType(ConditionTypeConstants.READY)
                 .filter(c -> c.getStatus() == ConditionStatus.False).isPresent()) {
+            LOGGER.info("Existing BridgeExecutor has been marked as READY:False. Skipping.");
             return false;
         }
         // Specs differ. Update it.

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeIngressServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeIngressServiceImpl.java
@@ -79,6 +79,7 @@ public class BridgeIngressServiceImpl implements BridgeIngressService {
     private boolean createOrReplace(BridgeIngress expected, BridgeIngress existing) {
         // Does not exist. Create it.
         if (existing == null) {
+            LOGGER.info("Existing BridgeIngress does not exist. Creating a new instance.");
             return true;
         }
         // Does exist, but it has already entered the Kubernetes reconciliation loop. Don't update it.
@@ -87,6 +88,7 @@ public class BridgeIngressServiceImpl implements BridgeIngressService {
         if (existing.getStatus()
                 .getConditionByType(ConditionTypeConstants.READY)
                 .filter(c -> c.getStatus() == ConditionStatus.False).isPresent()) {
+            LOGGER.info("Existing BridgeIngress has been marked as READY:False. Skipping.");
             return false;
         }
         // Specs differ. Update it.

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeIngressServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/BridgeIngressServiceImpl.java
@@ -82,6 +82,8 @@ public class BridgeIngressServiceImpl implements BridgeIngressService {
             return true;
         }
         // Does exist, but it has already entered the Kubernetes reconciliation loop. Don't update it.
+        // The expected definition will always have READY:Unknown set by BridgeIngress.Builder.build().
+        // READY:False is set by the first iteration through k8s's reconciliation loop.
         if (existing.getStatus()
                 .getConditionByType(ConditionTypeConstants.READY)
                 .filter(c -> c.getStatus() == ConditionStatus.False).isPresent()) {

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceImpl.java
@@ -81,6 +81,12 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
                                         },
                                         failure -> failedToSendUpdateToManager(y, failure));
                     }
+                    if (y.getStatus().equals(ManagedResourceStatus.PROVISIONING)) { // Bridges that were being provisioned (before the Operator failed).
+                        return Uni.createFrom().voidItem().invoke(() -> createBridgeIngress(y));
+                    }
+                    if (y.getStatus().equals(ManagedResourceStatus.DELETING)) { // Bridges that were being deleted (before the Operator failed).
+                        return Uni.createFrom().voidItem().invoke(() -> deleteBridgeIngress(y));
+                    }
                     LOGGER.warn("Manager included a Bridge '{}' instance with an illegal status '{}'", y.getId(), y.getStatus());
                     return Uni.createFrom().voidItem();
                 }).collect(Collectors.toList())));
@@ -108,6 +114,12 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
                                             deleteBridgeExecutor(y);
                                         },
                                         failure -> failedToSendUpdateToManager(y, failure));
+                    }
+                    if (y.getStatus().equals(ManagedResourceStatus.PROVISIONING)) { // Processors that were being provisioned (before the Operator failed).
+                        return Uni.createFrom().voidItem().invoke(() -> createBridgeExecutor(y));
+                    }
+                    if (y.getStatus().equals(ManagedResourceStatus.DELETING)) { // Processors that were being deleted (before the Operator failed).
+                        return Uni.createFrom().voidItem().invoke(() -> deleteBridgeExecutor(y));
                     }
                     return Uni.createFrom().voidItem();
                 }).collect(Collectors.toList())));

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/controllers/BridgeIngressController.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/controllers/BridgeIngressController.java
@@ -88,8 +88,7 @@ public class BridgeIngressController implements Reconciler<BridgeIngress>,
                 c.getReason()));
 
         // Mark CRD as being reconciled
-        if (bridgeIngress.getStatus()
-                .getConditionByType(ConditionTypeConstants.READY)
+        if (status.getConditionByType(ConditionTypeConstants.READY)
                 .filter(c -> c.getStatus() != ConditionStatus.False)
                 .isPresent()) {
             LOGGER.info("Marking BridgeIngress '{}' in namespace '{}' as augmenting reconciliation.",

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/resources/ConditionReasonConstants.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/resources/ConditionReasonConstants.java
@@ -19,5 +19,6 @@ public class ConditionReasonConstants {
     public static final String NETWORK_RESOURCE_NOT_READY = "NetworkResourceNotReady";
     public static final String KNATIVE_BROKER_NOT_READY = "KnativeBrokerNotReady";
     public static final String PROMETHEUS_UNAVAILABLE = "PrometheusUnavailable";
+    public static final String RECONCILIATION_PROGRESSING = "ReconciliationProgressing";
     public static final String SECRETS_NOT_FOUND = "SecretsNotFound";
 }

--- a/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/BridgeExecutorServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/BridgeExecutorServiceTest.java
@@ -91,8 +91,8 @@ public class BridgeExecutorServiceTest {
 
         // Then
         Awaitility.await()
-                .atMost(Duration.ofMinutes(2))
-                .pollInterval(Duration.ofSeconds(5))
+                .atMost(Duration.ofMinutes(3))
+                .pollInterval(Duration.ofSeconds(10))
                 .untilAsserted(
                         () -> {
                             // The deployment is deployed by the controller
@@ -131,8 +131,8 @@ public class BridgeExecutorServiceTest {
 
         // Wait until deployment is created by the controller.
         Awaitility.await()
-                .atMost(Duration.ofMinutes(2))
-                .pollInterval(Duration.ofSeconds(5))
+                .atMost(Duration.ofMinutes(3))
+                .pollInterval(Duration.ofSeconds(10))
                 .untilAsserted(
                         () -> {
                             // The deployment is deployed by the controller

--- a/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/BridgeIngressServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/BridgeIngressServiceTest.java
@@ -88,8 +88,8 @@ public class BridgeIngressServiceTest {
 
         // Then
         Awaitility.await()
-                .atMost(Duration.ofMinutes(2))
-                .pollInterval(Duration.ofSeconds(5))
+                .atMost(Duration.ofMinutes(3))
+                .pollInterval(Duration.ofSeconds(10))
                 .untilAsserted(
                         () -> {
                             Secret secret = fetchBridgeIngressSecret(dto);

--- a/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceTest.java
@@ -80,8 +80,8 @@ public class ManagerSyncServiceTest extends AbstractManagerSyncServiceTest {
         String firstBridgeName = BridgeIngress.resolveResourceName(bridge1.getId());
         String secondBridgeName = BridgeIngress.resolveResourceName(bridge2.getId());
         Awaitility.await()
-                .atMost(Duration.ofMinutes(3))
-                .pollInterval(Duration.ofSeconds(5))
+                .atMost(Duration.ofMinutes(5))
+                .pollInterval(Duration.ofSeconds(10))
                 .untilAsserted(
                         () -> {
                             kubernetesResourcePatcher.patchReadyKnativeBroker(firstBridgeName, customerNamespace);

--- a/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceTest.java
@@ -165,8 +165,8 @@ public class ManagerSyncServiceTest extends AbstractManagerSyncServiceTest {
         String customerNamespace = customerNamespaceProvider.resolveName(TestSupport.CUSTOMER_ID);
         String sanitizedName = BridgeExecutor.resolveResourceName(processor.getId());
         Awaitility.await()
-                .atMost(Duration.ofMinutes(3))
-                .pollInterval(Duration.ofSeconds(5))
+                .atMost(Duration.ofMinutes(5))
+                .pollInterval(Duration.ofSeconds(10))
                 .untilAsserted(
                         () -> {
                             kubernetesResourcePatcher.patchReadyDeploymentAsReady(sanitizedName, customerNamespace);


### PR DESCRIPTION
**=== DRAFT ===** 

This is to gather opinions before I spend much time writing tests.

[https://issues.redhat.com/browse/MGDOBR-441](https://issues.redhat.com/browse/MGDOBR-441)

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
