### PR TITLE
MGDOBR-441: Shard may never delete resources if it crashes after sending DELETING status call

### DIFF
--- a/manager/src/main/java/com/redhat/service/smartevents/manager/models/Bridge.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/models/Bridge.java
@@ -23,7 +23,11 @@ import com.redhat.service.smartevents.infra.models.bridges.BridgeDefinition;
                         "( " +
                         "  (status='PREPARING' and dependencyStatus='READY') " +
                         "  or " +
+                        "  (status='PROVISIONING' and dependencyStatus='READY') " +
+                        "  or " +
                         "  (status='DEPROVISION' and dependencyStatus='DELETED') " +
+                        "  or " +
+                        "  (status='DELETING' and dependencyStatus='DELETED') " +
                         ")"),
         @NamedQuery(name = "BRIDGE.findByNameAndCustomerId",
                 query = "from Bridge where name=:name and customer_id=:customerId"),

--- a/manager/src/main/java/com/redhat/service/smartevents/manager/models/Processor.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/models/Processor.java
@@ -44,7 +44,11 @@ import io.quarkiverse.hibernate.types.json.JsonTypes;
                         "    (" +
                         "      (p.status='PREPARING' and p.dependencyStatus='READY') " +
                         "      or " +
+                        "      (p.status='PROVISIONING' and p.dependencyStatus='READY') " +
+                        "      or " +
                         "      (p.status='DEPROVISION' and p.dependencyStatus='DELETED') " +
+                        "      or " +
+                        "      (p.status='DELETING' and p.dependencyStatus='DELETED') " +
                         "    )" +
                         "  )" +
                         ") or (" +

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/BridgesServiceTest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/BridgesServiceTest.java
@@ -162,7 +162,9 @@ public class BridgesServiceTest {
         bridge.setStatus(PROVISIONING);
         bridgesService.updateBridge(bridgesService.toDTO(bridge));
 
-        assertThat(bridgesService.findByShardIdWithReadyDependencies(SHARD_ID)).isEmpty();
+        // PROVISIONING Bridges are also notified to the Shard Operator.
+        // This ensures Bridges are not dropped should the Shard fail after notifying the Managed a Bridge is being provisioned.
+        assertThat(bridgesService.findByShardIdWithReadyDependencies(SHARD_ID)).hasSize(1);
 
         Bridge retrievedBridge = bridgesService.getBridge(bridge.getId(), DEFAULT_CUSTOMER_ID);
         assertThat(retrievedBridge.getStatus()).isEqualTo(PROVISIONING);

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/api/internal/ShardBridgesSyncAPITest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/api/internal/ShardBridgesSyncAPITest.java
@@ -322,11 +322,13 @@ public class ShardBridgesSyncAPITest {
         bridge.setStatus(PROVISIONING);
         TestUtils.updateBridge(bridge).then().statusCode(200);
 
+        // PROVISIONING Bridges are also notified to the Shard Operator.
+        // This ensures Bridges are not dropped should the Shard fail after notifying the Managed a Bridge is being provisioned.
         await().atMost(5, SECONDS).untilAsserted(() -> {
             bridgesToDeployOrDelete.clear();
             bridgesToDeployOrDelete.addAll(TestUtils.getBridgesToDeployOrDelete().as(new TypeRef<List<BridgeDTO>>() {
             }));
-            assertThat(bridgesToDeployOrDelete).isEmpty();
+            assertThat(bridgesToDeployOrDelete.stream().filter(x -> x.getStatus().equals(PROVISIONING)).count()).isEqualTo(1);
         });
     }
 

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/dao/BridgeDAOTest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/dao/BridgeDAOTest.java
@@ -61,6 +61,14 @@ public class BridgeDAOTest {
         retrievedBridges = bridgeDAO.findByShardIdWithReadyDependencies(TestConstants.SHARD_ID);
         assertThat(retrievedBridges.size()).isEqualTo(1);
 
+        // Emulate dependencies being completed and Operator started provisioning
+        bridge.setStatus(ManagedResourceStatus.PROVISIONING);
+        bridge.setDependencyStatus(READY);
+        bridgeDAO.persist(bridge);
+
+        retrievedBridges = bridgeDAO.findByShardIdWithReadyDependencies(TestConstants.SHARD_ID);
+        assertThat(retrievedBridges.size()).isEqualTo(1);
+
         // Emulate de-provision request
         bridge.setStatus(ManagedResourceStatus.DEPROVISION);
         bridge.setDependencyStatus(READY);
@@ -70,6 +78,14 @@ public class BridgeDAOTest {
         assertThat(retrievedBridges).isEmpty();
 
         // Emulate dependencies being deleted
+        bridge.setDependencyStatus(ManagedResourceStatus.DELETED);
+        bridgeDAO.persist(bridge);
+
+        retrievedBridges = bridgeDAO.findByShardIdWithReadyDependencies(TestConstants.SHARD_ID);
+        assertThat(retrievedBridges.size()).isEqualTo(1);
+
+        // Emulate dependencies being deleted and Operator started deleting
+        bridge.setStatus(ManagedResourceStatus.DELETING);
         bridge.setDependencyStatus(ManagedResourceStatus.DELETED);
         bridgeDAO.persist(bridge);
 

--- a/manager/src/test/java/com/redhat/service/smartevents/manager/dao/ProcessorDAOTest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/dao/ProcessorDAOTest.java
@@ -149,9 +149,21 @@ public class ProcessorDAOTest {
         r.setDependencyStatus(ManagedResourceStatus.DELETED);
         processorDAO.getEntityManager().merge(r);
 
+        //In the process of being provisioned
+        Processor s = createProcessor(b, "mary");
+        s.setStatus(ManagedResourceStatus.PROVISIONING);
+        s.setDependencyStatus(ManagedResourceStatus.READY);
+        processorDAO.getEntityManager().merge(s);
+
+        //In the process of being deleted
+        Processor t = createProcessor(b, "sue");
+        t.setStatus(ManagedResourceStatus.DELETING);
+        t.setDependencyStatus(ManagedResourceStatus.DELETED);
+        processorDAO.getEntityManager().merge(t);
+
         List<Processor> processors = processorDAO.findByShardIdWithReadyDependencies(TestConstants.SHARD_ID);
-        assertThat(processors).hasSize(2);
-        processors.forEach((px) -> assertThat(px.getName()).isIn("foo", "frank"));
+        assertThat(processors).hasSize(4);
+        processors.forEach((px) -> assertThat(px.getName()).isIn("foo", "frank", "mary", "sue"));
     }
 
     @Test

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceImpl.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/ManagerSyncServiceImpl.java
@@ -74,7 +74,8 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
                     }
                     if (y.getStatus().equals(ManagedResourceStatus.PROVISIONING)) { // Bridges that were being provisioned (before the Operator failed).
                         LOGGER.info("Found Bridge '{}' in PROVISIONING state. Attempting to continue with PROVISIONING.", y.getId());
-                        return Uni.createFrom().voidItem().subscribe().with(success -> createBridgeIngress(y));
+                        createBridgeIngress(y);
+                        return Uni.createFrom().voidItem();
                     }
                     if (y.getStatus().equals(ManagedResourceStatus.DEPROVISION)) { // Bridges to delete
                         LOGGER.info("Found Bridge '{}' in DEPROVISION state. Moving to DELETING.", y.getId());
@@ -89,7 +90,8 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
                     }
                     if (y.getStatus().equals(ManagedResourceStatus.DELETING)) { // Bridges that were being deleted (before the Operator failed).
                         LOGGER.info("Found Bridge '{}' in DELETING state. Attempting to continue with DELETING.", y.getId());
-                        return Uni.createFrom().voidItem().subscribe().with(success -> deleteBridgeIngress(y));
+                        deleteBridgeIngress(y);
+                        return Uni.createFrom().voidItem();
                     }
                     LOGGER.warn("Manager included a Bridge '{}' instance with an illegal status '{}'", y.getId(), y.getStatus());
                     return Uni.createFrom().voidItem();
@@ -112,7 +114,8 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
                     }
                     if (y.getStatus().equals(ManagedResourceStatus.PROVISIONING)) { // Processors that were being provisioned (before the Operator failed).
                         LOGGER.info("Found Processor '{}' in PROVISIONING state. Attempting to continue with PROVISIONING.", y.getId());
-                        return Uni.createFrom().voidItem().subscribe().with(success -> createBridgeExecutor(y));
+                        createBridgeExecutor(y);
+                        return Uni.createFrom().voidItem();
                     }
                     if (ManagedResourceStatus.DEPROVISION.equals(y.getStatus())) { // Processor to delete
                         LOGGER.info("Found Processor '{}' in DEPROVISION state. Moving to DELETING.", y.getId());
@@ -127,7 +130,8 @@ public class ManagerSyncServiceImpl implements ManagerSyncService {
                     }
                     if (y.getStatus().equals(ManagedResourceStatus.DELETING)) { // Processors that were being deleted (before the Operator failed).
                         LOGGER.info("Found Processor '{}' in DELETING state. Attempting to continue with DELETING.", y.getId());
-                        return Uni.createFrom().voidItem().subscribe().with(success -> deleteBridgeExecutor(y));
+                        deleteBridgeExecutor(y);
+                        return Uni.createFrom().voidItem();
                     }
                     return Uni.createFrom().voidItem();
                 }).collect(Collectors.toList())));


### PR DESCRIPTION
[https://issues.redhat.com/browse/MGDOBR-441](https://issues.redhat.com/browse/MGDOBR-441)

I'm not entirely convinced this is the best approach and would welcome thoughts.

At the moment we have a small window of potential failure between us advising the `manager` that a resource is being provisioned and us actually asking k8s to create or replace the CRD. Once we've told k8s then we're bullet proof. I was toying with the idea of a much larger refactor that puts the "tell the manager" call and "tell k8s" much closer together; but even if they're subsequent lines there will always remain potential for failure.

What's in this PR works; but I am not convinced it adds more smell to the code than it fixes. 

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
