### PR TITLE
[NO JIRA] Logs WebHook.site request failures

### DIFF
--- a/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/resources/webhook/site/WebhookSiteResource.java
+++ b/integration-tests/src/test/java/com/redhat/service/smartevents/integration/tests/resources/webhook/site/WebhookSiteResource.java
@@ -14,6 +14,8 @@ public class WebhookSiteResource {
     public static List<WebhookSiteRequest> requests(WebhookSiteQuerySorting sorting) {
         return RestAssured.get(ENDPOINT_BASE_URL + "/token/{webhookUuid}/requests?sorting={sorting}", getEndpointUuid(), sorting.getValue())
                 .then()
+                .log().ifValidationFails()
+                .statusCode(200)
                 .extract()
                 .body()
                 .jsonPath().getList("data", WebhookSiteRequest.class);
@@ -26,6 +28,7 @@ public class WebhookSiteResource {
                         getEndpointUuid(),
                         request.getUuid())
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200);
     }
 


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

Added missing logging, that should help us identifying possible issues with webhook.site requests.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
