### PR TITLE
MGDOBR-1037: Shard should verify hostname and SSL configuration of the Route exposed for a Bridge as part of the reconcile loop

### DIFF
--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftNetworkingService.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftNetworkingService.java
@@ -52,7 +52,7 @@ public class OpenshiftNetworkingService implements NetworkingService {
                 .withName(bridgeIngress.getMetadata().getName())
                 .get();
 
-        if (existing == null || !expected.getSpec().getTo().getName().equals(existing.getSpec().getTo().getName())) {
+        if (existing == null || !existing.getSpec().equals(expected.getSpec())) {
             client.routes()
                     .inNamespace(service.getMetadata().getNamespace())
                     .withName(bridgeIngress.getMetadata().getName())

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftNetworkingService.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftNetworkingService.java
@@ -21,6 +21,8 @@ import io.fabric8.openshift.api.model.RouteTargetReferenceBuilder;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 
+import static com.redhat.service.smartevents.shard.operator.networking.OpenshiftRouteSpecMatchesHelper.matches;
+
 public class OpenshiftNetworkingService implements NetworkingService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NetworkingService.class);
@@ -52,7 +54,7 @@ public class OpenshiftNetworkingService implements NetworkingService {
                 .withName(bridgeIngress.getMetadata().getName())
                 .get();
 
-        if (existing == null || !existing.getSpec().equals(expected.getSpec())) {
+        if (existing == null || !matches(existing.getSpec(), expected.getSpec())) {
             client.routes()
                     .inNamespace(service.getMetadata().getNamespace())
                     .withName(bridgeIngress.getMetadata().getName())

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelper.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelper.java
@@ -1,0 +1,86 @@
+package com.redhat.service.smartevents.shard.operator.networking;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.openshift.api.model.RouteSpec;
+
+public class OpenshiftRouteSpecMatchesHelper {
+
+    private OpenshiftRouteSpecMatchesHelper() {
+        //Static utility class
+    }
+
+    public static boolean matches(RouteSpec existing, RouteSpec expected) {
+        Function<RouteSpec, RouteSpec> spec = (RouteSpec source) -> source;
+        if (!Objects.equals(spec.apply(existing), spec.apply(expected))) {
+            return false;
+        }
+
+        Function<RouteSpec, String> host = (RouteSpec source) -> {
+            if (Objects.isNull(source)) {
+                return null;
+            }
+            return source.getHost();
+        };
+        if (!Objects.equals(host.apply(existing), host.apply(expected))) {
+            return false;
+        }
+
+        Function<RouteSpec, String> tlsConfigCertificate = (RouteSpec source) -> {
+            if (Objects.isNull(source)) {
+                return null;
+            }
+            if (Objects.isNull(source.getTls())) {
+                return null;
+            }
+            return source.getTls().getCertificate();
+        };
+        if (!Objects.equals(tlsConfigCertificate.apply(existing), tlsConfigCertificate.apply(expected))) {
+            return false;
+        }
+
+        Function<RouteSpec, String> tlsConfigKey = (RouteSpec source) -> {
+            if (Objects.isNull(source)) {
+                return null;
+            }
+            if (Objects.isNull(source.getTls())) {
+                return null;
+            }
+            return source.getTls().getKey();
+        };
+        if (!Objects.equals(tlsConfigKey.apply(existing), tlsConfigKey.apply(expected))) {
+            return false;
+        }
+
+        Function<RouteSpec, String> toName = (RouteSpec source) -> {
+            if (Objects.isNull(source)) {
+                return null;
+            }
+            if (Objects.isNull(source.getTo())) {
+                return null;
+            }
+            return source.getTo().getName();
+        };
+        if (!Objects.equals(toName.apply(existing), toName.apply(expected))) {
+            return false;
+        }
+
+        Function<RouteSpec, IntOrString> targetPort = (RouteSpec source) -> {
+            if (Objects.isNull(source)) {
+                return null;
+            }
+            if (Objects.isNull(source.getPort())) {
+                return null;
+            }
+            return source.getPort().getTargetPort();
+        };
+        if (!Objects.equals(targetPort.apply(existing), targetPort.apply(expected))) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelper.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelper.java
@@ -13,71 +13,61 @@ public class OpenshiftRouteSpecMatchesHelper {
     }
 
     public static boolean matches(RouteSpec existing, RouteSpec expected) {
-        Function<RouteSpec, RouteSpec> spec = (RouteSpec source) -> source;
-        if (!Objects.equals(spec.apply(existing), spec.apply(expected))) {
+        if (Objects.isNull(existing) && Objects.isNull(expected)) {
+            return true;
+        }
+        if (Objects.nonNull(existing) && Objects.isNull(expected)) {
             return false;
         }
-
-        Function<RouteSpec, String> host = (RouteSpec source) -> {
-            if (Objects.isNull(source)) {
-                return null;
-            }
-            return source.getHost();
-        };
+        if (Objects.isNull(existing)) {
+            return false;
+        }
+        Function<RouteSpec, String> host = RouteSpec::getHost;
         if (!Objects.equals(host.apply(existing), host.apply(expected))) {
             return false;
         }
 
-        Function<RouteSpec, String> tlsConfigCertificate = (RouteSpec source) -> {
-            if (Objects.isNull(source)) {
-                return null;
-            }
-            if (Objects.isNull(source.getTls())) {
-                return null;
-            }
-            return source.getTls().getCertificate();
-        };
-        if (!Objects.equals(tlsConfigCertificate.apply(existing), tlsConfigCertificate.apply(expected))) {
+        if (Objects.nonNull(existing.getTls()) && Objects.isNull(expected.getTls())) {
             return false;
         }
-
-        Function<RouteSpec, String> tlsConfigKey = (RouteSpec source) -> {
-            if (Objects.isNull(source)) {
-                return null;
-            }
-            if (Objects.isNull(source.getTls())) {
-                return null;
-            }
-            return source.getTls().getKey();
-        };
-        if (!Objects.equals(tlsConfigKey.apply(existing), tlsConfigKey.apply(expected))) {
+        if (Objects.isNull(existing.getTls()) && Objects.nonNull(expected.getTls())) {
             return false;
         }
-
-        Function<RouteSpec, String> toName = (RouteSpec source) -> {
-            if (Objects.isNull(source)) {
-                return null;
+        if (Objects.nonNull(existing.getTls()) && Objects.nonNull(expected.getTls())) {
+            Function<RouteSpec, String> tlsConfigCertificate = (RouteSpec source) -> source.getTls().getCertificate();
+            if (!Objects.equals(tlsConfigCertificate.apply(existing), tlsConfigCertificate.apply(expected))) {
+                return false;
             }
-            if (Objects.isNull(source.getTo())) {
-                return null;
+            Function<RouteSpec, String> tlsConfigKey = (RouteSpec source) -> source.getTls().getKey();
+            if (!Objects.equals(tlsConfigKey.apply(existing), tlsConfigKey.apply(expected))) {
+                return false;
             }
-            return source.getTo().getName();
-        };
-        if (!Objects.equals(toName.apply(existing), toName.apply(expected))) {
-            return false;
         }
 
-        Function<RouteSpec, IntOrString> targetPort = (RouteSpec source) -> {
-            if (Objects.isNull(source)) {
-                return null;
-            }
-            if (Objects.isNull(source.getPort())) {
-                return null;
-            }
-            return source.getPort().getTargetPort();
-        };
-        if (!Objects.equals(targetPort.apply(existing), targetPort.apply(expected))) {
+        if (Objects.nonNull(existing.getTo()) && Objects.isNull(expected.getTo())) {
             return false;
+        }
+        if (Objects.isNull(existing.getTo()) && Objects.nonNull(expected.getTo())) {
+            return false;
+        }
+        if (Objects.nonNull(existing.getTo()) && Objects.nonNull(expected.getTo())) {
+            Function<RouteSpec, String> toName = (RouteSpec source) -> source.getTo().getName();
+            if (!Objects.equals(toName.apply(existing), toName.apply(expected))) {
+                return false;
+            }
+        }
+
+        if (Objects.nonNull(existing.getPort()) && Objects.isNull(expected.getPort())) {
+            return false;
+        }
+        if (Objects.isNull(existing.getPort()) && Objects.nonNull(expected.getPort())) {
+            return false;
+        }
+        if (Objects.nonNull(existing.getPort()) && Objects.nonNull(expected.getPort())) {
+            Function<RouteSpec, IntOrString> targetPort = (RouteSpec source) -> source.getPort().getTargetPort();
+            if (!Objects.equals(targetPort.apply(existing), targetPort.apply(expected))) {
+                return false;
+            }
         }
 
         return true;

--- a/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelperTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelperTest.java
@@ -1,6 +1,8 @@
 package com.redhat.service.smartevents.shard.operator.networking;
 
 import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,22 +54,31 @@ public class OpenshiftRouteSpecMatchesHelperTest {
             RoutePort routePort,
             String port) {
         if (Objects.nonNull(spec)) {
+            setUncheckedProperty(spec::setPath);
             if (Objects.nonNull(tlsConfig)) {
                 spec.setTls(tlsConfig);
+                setUncheckedProperty(tlsConfig::setCaCertificate);
                 tlsConfig.setCertificate(tlsCertificate);
                 tlsConfig.setKey(tlsKey);
             }
             if (Objects.nonNull(to)) {
                 spec.setTo(to);
+                setUncheckedProperty(to::setKind);
                 to.setName(name);
             }
             if (Objects.nonNull(routePort)) {
                 spec.setPort(routePort);
+                setUncheckedProperty((v) -> routePort.setAdditionalProperty("unchecked", v));
                 routePort.setTargetPort(new IntOrString(port));
             }
         }
 
         return spec;
+    }
+
+    // Set a unique value for unchecked properties as they should make no difference on the comparisons
+    private void setUncheckedProperty(Consumer<String> setter) {
+        setter.accept(UUID.randomUUID().toString());
     }
 
     private static Stream<Arguments> routeSpecParameters() {

--- a/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelperTest.java
+++ b/shard-operator/src/test/java/com/redhat/service/smartevents/shard/operator/networking/OpenshiftRouteSpecMatchesHelperTest.java
@@ -1,0 +1,104 @@
+package com.redhat.service.smartevents.shard.operator.networking;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.openshift.api.model.RoutePort;
+import io.fabric8.openshift.api.model.RouteSpec;
+import io.fabric8.openshift.api.model.RouteTargetReference;
+import io.fabric8.openshift.api.model.TLSConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OpenshiftRouteSpecMatchesHelperTest {
+
+    @ParameterizedTest
+    @MethodSource("routeSpecParameters")
+    void testParameters(RouteSpec existingSpec, RouteSpec expectedSpec,
+            TLSConfig existingTLSConfig, TLSConfig expectedTLSConfig,
+            String existingTLSCertificate, String expectedTLSCertificate,
+            String existingTLSKey, String expectedTLSKey,
+            RouteTargetReference existingTo, RouteTargetReference expectedTo,
+            String existingName, String expectedName,
+            RoutePort existingRoutePort, RoutePort expectedRoutePort,
+            String existingPort, String expectedPort,
+            boolean matches) {
+        RouteSpec existing = buildRouteSpec(existingSpec,
+                existingTLSConfig, existingTLSCertificate, existingTLSKey,
+                existingTo,
+                existingName,
+                existingRoutePort,
+                existingPort);
+        RouteSpec expected = buildRouteSpec(expectedSpec,
+                expectedTLSConfig, expectedTLSCertificate, expectedTLSKey,
+                expectedTo,
+                expectedName,
+                expectedRoutePort,
+                expectedPort);
+        assertThat(OpenshiftRouteSpecMatchesHelper.matches(existing, expected)).isEqualTo(matches);
+    }
+
+    private RouteSpec buildRouteSpec(RouteSpec spec,
+            TLSConfig tlsConfig,
+            String tlsCertificate,
+            String tlsKey,
+            RouteTargetReference to,
+            String name,
+            RoutePort routePort,
+            String port) {
+        if (Objects.nonNull(spec)) {
+            if (Objects.nonNull(tlsConfig)) {
+                spec.setTls(tlsConfig);
+                tlsConfig.setCertificate(tlsCertificate);
+                tlsConfig.setKey(tlsKey);
+            }
+            if (Objects.nonNull(to)) {
+                spec.setTo(to);
+                to.setName(name);
+            }
+            if (Objects.nonNull(routePort)) {
+                spec.setPort(routePort);
+                routePort.setTargetPort(new IntOrString(port));
+            }
+        }
+
+        return spec;
+    }
+
+    private static Stream<Arguments> routeSpecParameters() {
+        Object[][] arguments = {
+                { null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, true },
+                { new RouteSpec(), null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, false },
+                { null, new RouteSpec(), null, null, null, null, null, null, null, null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, null, null, null, null, null, null, null, true },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), null, null, null, null, null, null, null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, new TLSConfig(), null, null, null, null, null, null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), new TLSConfig(), null, null, null, null, null, null, null, null, null, null, null, null, true },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), new TLSConfig(), "cert1", null, null, null, null, null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), new TLSConfig(), null, "cert1", null, null, null, null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), new TLSConfig(), "cert1", "cert1", null, null, null, null, null, null, null, null, null, null, true },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), new TLSConfig(), null, null, "key1", null, null, null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), new TLSConfig(), null, null, null, "key1", null, null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), new TLSConfig(), new TLSConfig(), null, null, "key1", "key1", null, null, null, null, null, null, null, null, true },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, new RouteTargetReference(), null, null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, new RouteTargetReference(), null, null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, new RouteTargetReference(), new RouteTargetReference(), null, null, null, null, null, null, true },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, new RouteTargetReference(), new RouteTargetReference(), "name1", null, null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, new RouteTargetReference(), new RouteTargetReference(), null, "name1", null, null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, new RouteTargetReference(), new RouteTargetReference(), "name1", "name1", null, null, null, null, true },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, null, null, null, new RoutePort(), null, null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, null, null, null, null, new RoutePort(), null, null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, null, null, null, new RoutePort(), new RoutePort(), null, null, true },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, null, null, null, new RoutePort(), new RoutePort(), "port1", null, false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, null, null, null, new RoutePort(), new RoutePort(), null, "port1", false },
+                { new RouteSpec(), new RouteSpec(), null, null, null, null, null, null, null, null, null, null, new RoutePort(), new RoutePort(), "port1", "port1", true }
+        };
+        return Stream.of(arguments).map(Arguments::of);
+    }
+
+}


### PR DESCRIPTION
[https://issues.redhat.com/browse/MGDOBR-1037](https://issues.redhat.com/browse/MGDOBR-1037)

It's not clear what `RouteSpec` properties we should be considering in the comparison.

However, since `RouteSpec` overrides `equals(..)` delegate complete comparison to it.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
