### PR TITLE
MGDOBR-1035: Shard does not report Bridge as Failed if Knative Broker resource does not deploy (#1126) - Update kustomization images

### DIFF
--- a/kustomize/base-openshift/kustomization.yaml
+++ b/kustomize/base-openshift/kustomization.yaml
@@ -4,7 +4,7 @@ images:
   newTag: b5013133a7515e64ac3deaf1af8c583046af2263-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
-  newTag: ocp-6e0501a345d4e5d06e1935525412ff3219c57f74-jvm
+  newTag: ocp-06c25e86012e1bea8dd884687bce915717b0884f-jvm
 patchesStrategicMerge:
 - manager/patches/deploy.yaml
 - manager/patches/deploy-config.yaml

--- a/kustomize/overlays/ci/kustomization.yaml
+++ b/kustomize/overlays/ci/kustomization.yaml
@@ -4,7 +4,7 @@ images:
   newTag: b5013133a7515e64ac3deaf1af8c583046af2263-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
-  newTag: k8s-6e0501a345d4e5d06e1935525412ff3219c57f74-jvm
+  newTag: k8s-06c25e86012e1bea8dd884687bce915717b0884f-jvm
 resources:
 - prometheus
 - shard


### PR DESCRIPTION
This Pull request aims to update the kustomization images for the PR MGDOBR-1035: Shard does not report Bridge as Failed if Knative Broker resource does not deploy (#1126)