### PR TITLE
MGDOBR-1035: Shard does not report Bridge as Failed if Knative Broker resource does not deploy. Rename and adjust poll parameters. (#1148) - Update kustomization images

### DIFF
--- a/kustomize/base-openshift/kustomization.yaml
+++ b/kustomize/base-openshift/kustomization.yaml
@@ -1,10 +1,10 @@
 images:
 - name: event-bridge-manager
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-manager
-  newTag: b5013133a7515e64ac3deaf1af8c583046af2263-jvm
+  newTag: 6478605632dcbde8022af96e6dc6a71f199180c1-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
-  newTag: ocp-06c25e86012e1bea8dd884687bce915717b0884f-jvm
+  newTag: ocp-7eb81a0a7b050a6294308a9e9c730e190a062b03-jvm
 patchesStrategicMerge:
 - manager/patches/deploy.yaml
 - manager/patches/deploy-config.yaml

--- a/kustomize/base-openshift/shard/patches/deploy-config.yaml
+++ b/kustomize/base-openshift/shard/patches/deploy-config.yaml
@@ -3,9 +3,9 @@ data:
   EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:6e0501a345d4e5d06e1935525412ff3219c57f74-jvm
   EVENT_BRIDGE_ISTIO_GATEWAY_NAME: istio-ingressgateway
   EVENT_BRIDGE_ISTIO_GATEWAY_NAMESPACE: istio-system
-  EVENT_BRIDGE_K8S_ORCHESTRATOR: openshift
   EVENT_BRIDGE_ISTIO_JWT_ISSUER: https://sso.redhat.com/auth/realms/redhat-external
   EVENT_BRIDGE_ISTIO_JWT_JWKSURI: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
+  EVENT_BRIDGE_K8S_ORCHESTRATOR: openshift
 kind: ConfigMap
 metadata:
   name: event-bridge-shard-operator-config

--- a/kustomize/overlays/ci/kustomization.yaml
+++ b/kustomize/overlays/ci/kustomization.yaml
@@ -1,10 +1,10 @@
 images:
 - name: event-bridge-manager
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-manager
-  newTag: b5013133a7515e64ac3deaf1af8c583046af2263-jvm
+  newTag: 6478605632dcbde8022af96e6dc6a71f199180c1-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
-  newTag: k8s-06c25e86012e1bea8dd884687bce915717b0884f-jvm
+  newTag: k8s-7eb81a0a7b050a6294308a9e9c730e190a062b03-jvm
 resources:
 - prometheus
 - shard

--- a/kustomize/overlays/ci/shard/patches/deploy-config.yaml
+++ b/kustomize/overlays/ci/shard/patches/deploy-config.yaml
@@ -3,10 +3,10 @@ data:
   EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:6e0501a345d4e5d06e1935525412ff3219c57f74-jvm
   EVENT_BRIDGE_ISTIO_GATEWAY_NAME: istio-ingressgateway
   EVENT_BRIDGE_ISTIO_GATEWAY_NAMESPACE: istio-system
-  EVENT_BRIDGE_K8S_ORCHESTRATOR: minikube
-  INGRESS_OVERRIDE_HOSTNAME: <REPLACE_WITH_KIND_HOSTNAME_OR_MINIKUBE_IP>
   EVENT_BRIDGE_ISTIO_JWT_ISSUER: https://sso.redhat.com/auth/realms/redhat-external
   EVENT_BRIDGE_ISTIO_JWT_JWKSURI: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
+  EVENT_BRIDGE_K8S_ORCHESTRATOR: minikube
+  INGRESS_OVERRIDE_HOSTNAME: <REPLACE_WITH_KIND_HOSTNAME_OR_MINIKUBE_IP>
 kind: ConfigMap
 metadata:
   name: event-bridge-shard-operator-config


### PR DESCRIPTION
This Pull request aims to update the kustomization images for the PR MGDOBR-1035: Shard does not report Bridge as Failed if Knative Broker resource does not deploy. Rename and adjust poll parameters. (#1148)