### PR TITLE
MGDOBR-1085: enlarge timeout for provisioning from 1 minute to 5 minutes

### DIFF
--- a/shard-operator/src/main/resources/application.properties
+++ b/shard-operator/src/main/resources/application.properties
@@ -8,9 +8,9 @@ quarkus.container-image.tag=latest
 quarkus.container-image.build=false
 
 event-bridge.executor.image=${EVENT_BRIDGE_EXECUTOR_IMAGE:openbridge/executor:latest}
-event-bridge.executor.deployment.timeout-seconds=60
+event-bridge.executor.deployment.timeout-seconds=300
 event-bridge.executor.poll-interval.milliseconds=5000
-event-bridge.ingress.deployment.timeout-seconds=60
+event-bridge.ingress.deployment.timeout-seconds=300
 event-bridge.ingress.poll-interval.milliseconds=5000
 
 event-bridge.manager.url=${EVENT_BRIDGE_MANAGER_URL:http://localhost:8080}

--- a/shard-operator/src/test/resources/application.properties
+++ b/shard-operator/src/test/resources/application.properties
@@ -14,10 +14,12 @@ event-bridge.istio.gateway.namespace=istio-system
 quarkus.log.console.json=${event-bridge.logging.json:false}
 
 # See BridgeIngressServiceTest.testBridgeIngressCreationWhenSpecAlreadyExistsAsFailed()
-%test.quarkus.operator-sdk.controllers."bridgeingresscontroller".retry.max-attempts=1
+quarkus.operator-sdk.controllers."bridgeingresscontroller".retry.max-attempts=1
 
 # See BridgeExecutorServiceTest.testBridgeExecutorCreationWhenSpecAlreadyExistsAsFailedMaxRetries()
-%test.quarkus.operator-sdk.controllers."bridgeexecutorcontroller".retry.max-attempts=1
+quarkus.operator-sdk.controllers."bridgeexecutorcontroller".retry.max-attempts=1
 
-%test.event-bridge.executor.poll-interval.milliseconds=250
-%test.event-bridge.ingress.poll-interval.milliseconds=250
+event-bridge.executor.poll-interval.milliseconds=250
+event-bridge.ingress.poll-interval.milliseconds=250
+event-bridge.executor.deployment.timeout-seconds=60
+event-bridge.ingress.deployment.timeout-seconds=60


### PR DESCRIPTION
[MGDOBR-1085](https://issues.redhat.com/browse/MGDOBR-1085)

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
