### PR TITLE
MGDOBR-1113: Unit Test: Call to getProcessors with name filter fails when too quick after processor creation. Not an issue.

### DIFF
--- a/manager/src/test/java/com/redhat/service/smartevents/manager/api/user/BridgesAPITest.java
+++ b/manager/src/test/java/com/redhat/service/smartevents/manager/api/user/BridgesAPITest.java
@@ -311,6 +311,28 @@ public class BridgesAPITest {
 
     @Test
     @TestSecurity(user = DEFAULT_CUSTOMER_ID)
+    // See https://issues.redhat.com/browse/MGDOBR-1113
+    public void testGetBridgesFilterByNameWithCreationByApi() {
+        BridgeRequest bridge1 = new BridgeRequest(DEFAULT_BRIDGE_NAME + "1", DEFAULT_CLOUD_PROVIDER, DEFAULT_REGION);
+        BridgeRequest bridge2 = new BridgeRequest(DEFAULT_BRIDGE_NAME + "2", DEFAULT_CLOUD_PROVIDER, DEFAULT_REGION);
+        TestUtils.createBridge(bridge1);
+        TestUtils.createBridge(bridge2);
+
+        BridgeListResponse bridgeListResponse = TestUtils.getBridgesFilterByName(DEFAULT_BRIDGE_NAME + "1").as(BridgeListResponse.class);
+
+        assertThat(bridgeListResponse.getItems().size()).isEqualTo(1);
+        BridgeResponse bridgeResponse = bridgeListResponse.getItems().get(0);
+        assertThat(bridgeResponse.getName()).isEqualTo(bridge1.getName());
+        assertThat(bridgeResponse.getStatus()).isEqualTo(ACCEPTED);
+        assertThat(bridgeResponse.getHref()).isEqualTo(USER_API_BASE_PATH + bridgeResponse.getId());
+        assertThat(bridgeResponse.getSubmittedAt()).isNotNull();
+        assertThat(bridgeResponse.getEndpoint()).isNull();
+        assertThat(bridgeResponse.getCloudProvider()).isEqualTo(DEFAULT_CLOUD_PROVIDER);
+        assertThat(bridgeResponse.getRegion()).isEqualTo(DEFAULT_REGION);
+    }
+
+    @Test
+    @TestSecurity(user = DEFAULT_CUSTOMER_ID)
     public void testGetBridgesFilterByStatus() {
         Bridge bridge1 = Fixtures.createBridge();
         bridge1.setName(DEFAULT_BRIDGE_NAME + "1");


### PR DESCRIPTION
[https://issues.redhat.com/browse/MGDOBR-1113](https://issues.redhat.com/browse/MGDOBR-1113)

Additional test for Bridge creation/filtering. A test already [exists](https://github.com/5733d9e2be6485d52ffa08870cabdee0/sandbox/blob/main/manager/src/test/java/com/redhat/service/smartevents/manager/api/user/ProcessorAPITest.java#L122) for Processors.

Both tests create and query without any delay.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
