### PR TITLE
MGDOBR-1113: Unit Test: Call to getProcessors with name filter fails when too quick after processor creation. Not an issue. (#1185) - Update kustomization images

### DIFF
--- a/kustomize/base-openshift/kustomization.yaml
+++ b/kustomize/base-openshift/kustomization.yaml
@@ -1,7 +1,7 @@
 images:
 - name: event-bridge-manager
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-manager
-  newTag: 0d8d9a6cacf225b67057930f253bb822a9b17589-jvm
+  newTag: e8b997941ab74d76bd3ceade77bd4c92dbd93c04-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
   newTag: ocp-cf652d96ccdce3d72ef35acfe8156bf94c309627-jvm

--- a/kustomize/overlays/ci/kustomization.yaml
+++ b/kustomize/overlays/ci/kustomization.yaml
@@ -1,7 +1,7 @@
 images:
 - name: event-bridge-manager
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-manager
-  newTag: 0d8d9a6cacf225b67057930f253bb822a9b17589-jvm
+  newTag: e8b997941ab74d76bd3ceade77bd4c92dbd93c04-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
   newTag: k8s-cf652d96ccdce3d72ef35acfe8156bf94c309627-jvm


### PR DESCRIPTION
This Pull request aims to update the kustomization images for the PR MGDOBR-1113: Unit Test: Call to getProcessors with name filter fails when too quick after processor creation. Not an issue. (#1185)