### PR TITLE
[MGDOBR-1122] Used in-memory scheduler for OIDC token refresh

### DIFF
--- a/executor/src/main/java/com/redhat/service/smartevents/executor/WebhookOidcClient.java
+++ b/executor/src/main/java/com/redhat/service/smartevents/executor/WebhookOidcClient.java
@@ -1,5 +1,7 @@
 package com.redhat.service.smartevents.executor;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -10,7 +12,6 @@ import com.redhat.service.smartevents.infra.auth.OidcClientConstants;
 
 import io.quarkus.oidc.client.OidcClientConfig;
 import io.quarkus.oidc.client.OidcClients;
-import io.quarkus.scheduler.Scheduled;
 
 @ApplicationScoped
 public class WebhookOidcClient extends AbstractOidcClient {
@@ -27,8 +28,8 @@ public class WebhookOidcClient extends AbstractOidcClient {
     String secret;
 
     @Inject
-    public WebhookOidcClient(OidcClients oidcClients) {
-        super(NAME, oidcClients);
+    public WebhookOidcClient(OidcClients oidcClients, ScheduledExecutorService executorService) {
+        super(NAME, oidcClients, executorService);
     }
 
     @Override
@@ -41,11 +42,5 @@ public class WebhookOidcClient extends AbstractOidcClient {
         oidcClientConfig.setRefreshTokenTimeSkew(AbstractOidcClient.REFRESH_TOKEN_TIME_SKEW);
 
         return oidcClientConfig;
-    }
-
-    @Override
-    @Scheduled(every = AbstractOidcClient.SCHEDULER_TIME)
-    protected void scheduledLoop() {
-        super.checkAndRefresh();
     }
 }

--- a/infra/src/main/java/com/redhat/service/smartevents/infra/auth/OidcSchedulerProducer.java
+++ b/infra/src/main/java/com/redhat/service/smartevents/infra/auth/OidcSchedulerProducer.java
@@ -1,0 +1,16 @@
+package com.redhat.service.smartevents.infra.auth;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+public class OidcSchedulerProducer {
+
+    @Produces
+    @ApplicationScoped
+    public ScheduledExecutorService produceScheduler() {
+        return Executors.newScheduledThreadPool(10);
+    }
+}

--- a/infra/src/test/java/com/redhat/service/smartevents/infra/AbstractOidcClientTest.java
+++ b/infra/src/test/java/com/redhat/service/smartevents/infra/AbstractOidcClientTest.java
@@ -1,5 +1,7 @@
 package com.redhat.service.smartevents.infra;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,17 +32,20 @@ public class AbstractOidcClientTest {
     private OidcClient oidcClient;
     private Tokens tokens;
     private TestOidcClient client;
+    private ScheduledExecutorService executorService;
 
     private static class TestOidcClient extends AbstractOidcClient {
 
-        public TestOidcClient(String name, OidcClients oidcClients) {
-            super(name, oidcClients);
+        public TestOidcClient(String name, OidcClients oidcClients, ScheduledExecutorService executorService) {
+            super(name, oidcClients, executorService);
         }
 
         @Override
         public void init() {
             super.init();
         }
+
+
 
         @Override
         public void checkAndRefresh() {
@@ -56,10 +61,6 @@ public class AbstractOidcClientTest {
         protected OidcClientConfig getOidcClientConfig() {
             return new OidcClientConfig();
         }
-
-        @Override
-        protected void scheduledLoop() {
-        }
     }
 
     @BeforeEach
@@ -68,13 +69,14 @@ public class AbstractOidcClientTest {
         OidcClients oidcClients = mock(OidcClients.class);
         oidcClient = mock(OidcClient.class);
         tokens = mock(Tokens.class);
+        executorService = mock(ScheduledExecutorService.class);
         when(tokens.getAccessToken()).thenReturn(ACCESS_TOKEN);
         when(tokens.getRefreshToken()).thenReturn(REFRESH_TOKEN);
         when(oidcClient.getTokens()).thenReturn(Uni.createFrom().item(tokens));
         when(oidcClient.refreshTokens(any(String.class))).thenReturn(Uni.createFrom().item(tokens));
         when(oidcClients.newClient(any(OidcClientConfig.class))).thenReturn(Uni.createFrom().item(oidcClient));
 
-        client = new TestOidcClient(NAME, oidcClients);
+        client = new TestOidcClient(NAME, oidcClients, executorService);
     }
 
     @Test

--- a/infra/src/test/java/com/redhat/service/smartevents/infra/AbstractOidcClientTest.java
+++ b/infra/src/test/java/com/redhat/service/smartevents/infra/AbstractOidcClientTest.java
@@ -45,8 +45,6 @@ public class AbstractOidcClientTest {
             super.init();
         }
 
-
-
         @Override
         public void checkAndRefresh() {
             super.checkAndRefresh();

--- a/manager/src/main/java/com/redhat/service/smartevents/manager/connectors/ConnectorsOidcClient.java
+++ b/manager/src/main/java/com/redhat/service/smartevents/manager/connectors/ConnectorsOidcClient.java
@@ -1,5 +1,7 @@
 package com.redhat.service.smartevents.manager.connectors;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -13,7 +15,6 @@ import com.redhat.service.smartevents.infra.auth.OidcClientConfigUtils;
 import io.quarkus.oidc.client.OidcClientConfig;
 import io.quarkus.oidc.client.OidcClients;
 import io.quarkus.oidc.common.runtime.OidcConstants;
-import io.quarkus.scheduler.Scheduled;
 
 @ApplicationScoped
 public class ConnectorsOidcClient extends AbstractOidcClient {
@@ -32,8 +33,8 @@ public class ConnectorsOidcClient extends AbstractOidcClient {
     String offlineToken;
 
     @Inject
-    public ConnectorsOidcClient(OidcClients oidcClients) {
-        super(NAME, oidcClients);
+    public ConnectorsOidcClient(OidcClients oidcClients, ScheduledExecutorService executorService) {
+        super(NAME, oidcClients, executorService);
     }
 
     @Override
@@ -48,12 +49,6 @@ public class ConnectorsOidcClient extends AbstractOidcClient {
         oidcClientConfig.setRefreshTokenTimeSkew(AbstractOidcClient.REFRESH_TOKEN_TIME_SKEW);
 
         return oidcClientConfig;
-    }
-
-    @Override
-    @Scheduled(every = AbstractOidcClient.SCHEDULER_TIME)
-    protected void scheduledLoop() {
-        super.checkAndRefresh();
     }
 
     @Override

--- a/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/EventBridgeOidcClient.java
+++ b/shard-operator/src/main/java/com/redhat/service/smartevents/shard/operator/EventBridgeOidcClient.java
@@ -1,5 +1,7 @@
 package com.redhat.service.smartevents.shard.operator;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -9,7 +11,6 @@ import com.redhat.service.smartevents.infra.auth.AbstractOidcClient;
 
 import io.quarkus.oidc.client.OidcClientConfig;
 import io.quarkus.oidc.client.OidcClients;
-import io.quarkus.scheduler.Scheduled;
 
 @ApplicationScoped
 public class EventBridgeOidcClient extends AbstractOidcClient {
@@ -26,8 +27,8 @@ public class EventBridgeOidcClient extends AbstractOidcClient {
     String secret;
 
     @Inject
-    public EventBridgeOidcClient(OidcClients oidcClients) {
-        super(NAME, oidcClients);
+    public EventBridgeOidcClient(OidcClients oidcClients, ScheduledExecutorService executorService) {
+        super(NAME, oidcClients, executorService);
     }
 
     @Override
@@ -40,11 +41,5 @@ public class EventBridgeOidcClient extends AbstractOidcClient {
         oidcClientConfig.setRefreshTokenTimeSkew(AbstractOidcClient.REFRESH_TOKEN_TIME_SKEW);
 
         return oidcClientConfig;
-    }
-
-    @Override
-    @Scheduled(every = AbstractOidcClient.SCHEDULER_TIME)
-    protected void scheduledLoop() {
-        super.checkAndRefresh();
     }
 }


### PR DESCRIPTION
When running with Quartz in a clustered environment the `@Scheduled` annotation causes the task to be executed on any node in the cluster. This is not what we want as we need each node to periodically refresh its own access token.

This commit replaces the Quartz scheduler with a simple in-memory ScheduledExecutorService to perform the OIDC token refresh

[MGDOBR-1122](https://issues.redhat.com/browse/MGDOBR-1122)

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
