### PR TITLE
[NO JIRA] E2E tests: Adjust Bridge creation timeouts

### DIFF
--- a/integration-tests/src/test/resources/features/bridge.feature
+++ b/integration-tests/src/test/resources/features/bridge.feature
@@ -9,5 +9,5 @@ Feature: Bridge tests
 
     When delete the Bridge "mybridge"
 
-    Then the Bridge "mybridge" is not existing within 2 minutes
+    Then the Bridge "mybridge" is not existing within 4 minutes
     And the Ingress of Bridge "mybridge" is not available within 1 minute

--- a/integration-tests/src/test/resources/features/error-handling.feature
+++ b/integration-tests/src/test/resources/features/error-handling.feature
@@ -19,7 +19,7 @@ Feature: Error handling tests
         }
     }
     """
-    And the Bridge "ehBridge" is existing with status "ready" within 4 minutes
+    And the Bridge "ehBridge" is existing with status "ready" within 6 minutes
     And the Ingress of Bridge "ehBridge" is available within 2 minutes
 
     And add a Processor to the Bridge "ehBridge" with body:
@@ -72,7 +72,7 @@ Feature: Error handling tests
         }
     }
     """
-    And the Bridge "ehBridgeUpdate" is existing with status "ready" within 4 minutes
+    And the Bridge "ehBridgeUpdate" is existing with status "ready" within 6 minutes
     And the Ingress of Bridge "ehBridgeUpdate" is available within 2 minutes
 
     When update the Bridge "ehBridgeUpdate" with body:
@@ -89,7 +89,7 @@ Feature: Error handling tests
         }
     }
     """
-    And the Bridge "ehBridgeUpdate" is existing with status "ready" within 4 minutes
+    And the Bridge "ehBridgeUpdate" is existing with status "ready" within 6 minutes
     And the Bridge "ehBridgeUpdate" has errorHandler of type "webhook_sink_0.1" and parameters:
       | endpoint | https://webhook.site/${env.webhook.site.uuid} |
     And the Ingress of Bridge "ehBridgeUpdate" is available within 2 minutes
@@ -140,7 +140,7 @@ Feature: Error handling tests
         }
     }
     """
-    And the Bridge "pollingEhBridge" is existing with status "ready" within 4 minutes
+    And the Bridge "pollingEhBridge" is existing with status "ready" within 6 minutes
     And the Bridge "pollingEhBridge" has a polling error handler endpoint
     And the Ingress of Bridge "pollingEhBridge" is available within 2 minutes
 


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

I have observed occasional timeouts in Bridge creation/deletion.
They seemed to be related to delay caused by Kafka timeouts.

Extending the timeouts for Bridges with error handler should stabilize the test suite.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
