### PR TITLE
Install serverless from midstream

### DIFF
--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -71,7 +71,7 @@ Required Operators:
 
 - Cluster Monitoring
 - Bitnami sealed secrets (via controller deployment below)
-- Openshift Serverless is installed with [this guide](https://docs.openshift.com/container-platform/4.8/serverless/install/install-serverless-operator.html).
+- Openshift Serverless is installed with [this guide](https://github.com/openshift-knative/serverless-operator/blob/main/docs/install-midstream.md).
 - Service Mesh is installed with [this guide](https://docs.openshift.com/container-platform/4.8/service_mesh/v2x/installing-ossm.html)
 
 ## Sealed Secrets
@@ -138,7 +138,7 @@ The command should complete and exit cleanly.
 ## Deploying the infrastructure to another cluster
 
 Assuming that the infrastructure version you'd like to deploy is the `stable` one, then the requirements are the following:
-1) The `OpenShift Serverless` operator is [installed](https://docs.openshift.com/container-platform/4.9/serverless/install/install-serverless-operator.html)
+1) The `OpenShift Serverless` operator is [installed](https://github.com/openshift-knative/serverless-operator/blob/main/docs/install-midstream.md)
 2) Install `Redhat OpenShift distributed tracing platform`, `Kiali`, `Red Hat OpenShift Service Mesh` according to [this documentation](https://docs.openshift.com/container-platform/4.9/service_mesh/v2x/installing-ossm.html).
 3) You have to provide all the secrets/configurations using AWS secret manager. Get in touch with the dev team for that. Assuming you have deployed new AWS secrets `myenv/fleet-manager` and `myenv/fleet-shard`, then 
    1) Replace the `spec/dataFrom/extract/key` of the resources `event-bridge-manager-secrets.yaml` and `addon-smart-events-operator-parameters.yaml` with `myenv/fleet-manager` and `myenv/fleet-shard`.

--- a/scripts/dependencies/README.md
+++ b/scripts/dependencies/README.md
@@ -5,6 +5,12 @@ The shard operator requires serverless [1] and servicemesh [2] operators (servic
 They can be installed, along with their additional configuration resources, by running the script `install_dependencies.sh`.
 The operators and their configuration resources can be removed by running `uninstall_dependencies.sh`.
 
+OpenShift Serverless is currently installed using the midstream operator. That is identical to the fully released product, except:
+- (pro) It is easier and faster to consume bug fixes
+- Midstream operator and Knative images use non-productized base images
+- (con) Serverless QA testing is done on the product operator, not the midstream one. However, as long as there is a
+  matching product, the midstream operator should be almost identical to it.
+
 ## Prerequisites
 - A compatible `oc` client binary on PATH
 - Before running any of the scripts, the `oc` client needs to be authenticated into the target cluster (`oc login`). 

--- a/scripts/dependencies/README.md
+++ b/scripts/dependencies/README.md
@@ -22,6 +22,6 @@ oc login --token=... --server=...
 ```
 
 ## References
-[1] https://docs.openshift.com/container-platform/4.11/serverless/install/install-serverless-operator.html
+[1] https://github.com/openshift-knative/serverless-operator/blob/main/docs/install-midstream.md
 
 [2] https://docs.openshift.com/container-platform/4.11/service_mesh/v2x/installing-ossm.html

--- a/scripts/dependencies/common_tools.sh
+++ b/scripts/dependencies/common_tools.sh
@@ -34,36 +34,37 @@ function waitForSuccess() {
     done
 }
 
-# Installs an operator according to given subscription resource and waits, params: operatorSubscriptionResource
+# Installs an operator according to given subscription resource and waits, params: operatorSubscriptionResource, namespace (defaults to openshift-operators)
 # Example:
 #  install_operator_and_wait serverless/serverlessSub.yaml
 #
 function install_operator_and_wait()
 {
   local resource=$1
+  local namespace=${2:-openshift-operators}
 
   echo "Applying $resource"
   oc apply -f "$resource"
   sleep 2
 
   echo "Waiting for operator installation plan"
-  OPERATOR_INST_PLAN=$(waitForOpResult 30 oc get -f "$resource" -n openshift-operators -o jsonpath={.status.installplan.name})
+  OPERATOR_INST_PLAN=$(waitForOpResult 30 oc get -f "$resource" -n $namespace -o jsonpath={.status.installplan.name})
   echo "Operator installation plan found: $OPERATOR_INST_PLAN"
 
   echo "Approving operator installation plan"
-  waitForSuccess 3 oc patch installplan.operators.coreos.com $OPERATOR_INST_PLAN -n openshift-operators --patch-file approve-ip-patch.json --type json
+  waitForSuccess 3 oc patch installplan.operators.coreos.com $OPERATOR_INST_PLAN -n $namespace --patch-file approve-ip-patch.json --type json
 
   echo "Waiting for operator CSV"
-  OPERATOR_CSV=$(waitForOpResult 30 oc get -f "$resource" -n openshift-operators -o jsonpath={.status.currentCSV})
+  OPERATOR_CSV=$(waitForOpResult 30 oc get -f "$resource" -n $namespace -o jsonpath={.status.currentCSV})
 
   echo "Operator CSV found: $OPERATOR_CSV"
   # wait for the resource to be available, oc wait might fail otherwise
-  waitForOpResult 60 oc get csv $OPERATOR_CSV -o jsonpath={.status.phase} -n openshift-operators
+  waitForOpResult 60 oc get csv $OPERATOR_CSV -o jsonpath={.status.phase} -n $namespace
   # wait for the second time to avoid race condition
-  waitForOpResult 30 oc get csv $OPERATOR_CSV -o jsonpath={.status.phase} -n openshift-operators
+  waitForOpResult 30 oc get csv $OPERATOR_CSV -o jsonpath={.status.phase} -n $namespace
   echo "Waiting for status.phase=Succeeded"
   # plain oc wait fails on network disconnect, hence the waitForSuccess call
-  waitForSuccess 3 oc wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=240s csv $OPERATOR_CSV -n openshift-operators
+  waitForSuccess 3 oc wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=240s csv $OPERATOR_CSV -n $namespace
 
   status=$?
   if [ $status -ne 0 ]; then
@@ -72,15 +73,16 @@ function install_operator_and_wait()
   fi
 }
 
-# Removes operator CSV and subscription, params: operatorSubscriptionResource
+# Removes operator CSV and subscription, params: operatorSubscriptionResource, namespace (defaults to openshift-operators)
 function uninstall_operator()
 {
   local resource=$1
+  local namespace=${2:-openshift-operators}
 
   echo "Deleting CSV and subscription for $resource"
   # Find the operator CSV first
-  OPERATOR_CSV=$(waitForOpResult 3 oc get -f "$resource" -n openshift-operators -o jsonpath={.status.installedCSV})
+  OPERATOR_CSV=$(waitForOpResult 3 oc get -f "$resource" -n "$namespace" -o jsonpath={.status.installedCSV})
   echo "Found operator CSV for removal: $OPERATOR_CSV"
-  waitForSuccess 3 oc delete -f "$resource" -n openshift-operators --ignore-not-found=true
-  waitForSuccess 3 oc delete csv $OPERATOR_CSV -n openshift-operators --ignore-not-found=true
+  waitForSuccess 3 oc delete -f "$resource" -n $namespace --ignore-not-found=true
+  waitForSuccess 3 oc delete csv $OPERATOR_CSV -n $namespace --ignore-not-found=true
 }

--- a/scripts/dependencies/install_dependencies.sh
+++ b/scripts/dependencies/install_dependencies.sh
@@ -7,8 +7,6 @@ echo "Installing Serverless Operator"
 waitForSuccess 10 oc apply -f serverless/serverless-system-namespace.yaml
 waitForSuccess 10 oc apply -f serverless/serverless-operator-group.yaml
 waitForSuccess 10 oc apply -f serverless/serverless-catalog-source.yaml
-# TODO: do we want to wait until catalog source is ready?
-# oc wait catalogsources -n openshift-marketplace serverless-operator-v1-24-0 --for=jsonpath='{.status.connectionState.lastObservedState}'="READY" --timeout=5m
 install_operator_and_wait serverless/serverlessSub.yaml openshift-serverless
 # set up serverless resources
 waitForSuccess 10 oc apply -k serverless

--- a/scripts/dependencies/install_dependencies.sh
+++ b/scripts/dependencies/install_dependencies.sh
@@ -3,8 +3,13 @@
 source common_tools.sh
 
 echo "Installing Serverless Operator"
-# based on https://docs.openshift.com/container-platform/4.11/serverless/install/install-serverless-operator.html
-install_operator_and_wait serverless/serverlessSub.yaml
+# based on https://github.com/openshift-knative/serverless-operator/blob/main/docs/install-midstream.md
+waitForSuccess 10 oc apply -f serverless/serverless-system-namespace.yaml
+waitForSuccess 10 oc apply -f serverless/serverless-operator-group.yaml
+waitForSuccess 10 oc apply -f serverless/serverless-catalog-source.yaml
+# TODO: do we want to wait until catalog source is ready?
+# oc wait catalogsources -n openshift-marketplace serverless-operator-v1-24-0 --for=jsonpath='{.status.connectionState.lastObservedState}'="READY" --timeout=5m
+install_operator_and_wait serverless/serverlessSub.yaml openshift-serverless
 # set up serverless resources
 waitForSuccess 10 oc apply -k serverless
 

--- a/scripts/dependencies/serverless/serverless-catalog-source.yaml
+++ b/scripts/dependencies/serverless/serverless-catalog-source.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  # Replace the version with whatever version you want to install
+  name: serverless-operator-v1-24-0
+  namespace: openshift-marketplace
+spec:
+  displayName: Serverless Operator
+  # Replace the version with whatever version you want to install
+  image: registry.ci.openshift.org/knative/openshift-serverless-v1.24.0:serverless-index
+  publisher: Red Hat
+  sourceType: grpc

--- a/scripts/dependencies/serverless/serverless-operator-group.yaml
+++ b/scripts/dependencies/serverless/serverless-operator-group.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: serverless
+  namespace: openshift-serverless

--- a/scripts/dependencies/serverless/serverless-system-namespace.yaml
+++ b/scripts/dependencies/serverless/serverless-system-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: openshift-serverless

--- a/scripts/dependencies/serverless/serverlessSub.yaml
+++ b/scripts/dependencies/serverless/serverlessSub.yaml
@@ -2,11 +2,12 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-serverless-operator-subscription
-  namespace: openshift-operators
+  namespace: openshift-serverless
 spec:
   channel: stable
   name: serverless-operator
-  source: redhat-operators
+  # consume from specific catalog source for the specific version of serverless midstream
+  source: serverless-operator-v1-24-0
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
   startingCSV: serverless-operator.v1.24.0

--- a/scripts/dependencies/uninstall_dependencies.sh
+++ b/scripts/dependencies/uninstall_dependencies.sh
@@ -16,5 +16,5 @@ echo "Removing Serverless resources"
 waitForSuccess 3 oc kustomize serverless | oc delete --ignore-not-found=true -f -
 
 echo "Removing Serverless Operator"
-# based on https://docs.openshift.com/container-platform/4.11/serverless/install/install-serverless-operator.html
-uninstall_operator serverless/serverlessSub.yaml
+# based on https://github.com/openshift-knative/serverless-operator/blob/main/docs/install-midstream.md
+uninstall_operator serverless/serverlessSub.yaml openshift-serverless


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDOBR-1127

Done:
- Install serverless from midstream
- Install serverless operator in another namespace (`openshift-serverless`) than `openshift-operators`. This is the recommended way. Also, existing installations are migrated to use this namespace per the [migration document](https://github.com/openshift-knative/serverless-operator/blob/main/docs/migrating-from-product-to-midstream.md).
- Make some shell functions accept an optional namespace argument

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
