### PR TITLE
[MGDOBR-1268] Implemented the v2 namespace strategy for the data plane

### DIFF
--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagedBridgeService.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagedBridgeService.java
@@ -1,0 +1,10 @@
+package com.redhat.service.smartevents.shard.operator.v2;
+
+import com.redhat.service.smartevents.shard.operator.v2.resources.ManagedBridge;
+
+public interface ManagedBridgeService {
+
+    void createManagedBridgeResources(ManagedBridge managedBridge);
+
+    void deleteManagedBridgeResources(ManagedBridge managedBridge);
+}

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagedBridgeServiceImpl.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagedBridgeServiceImpl.java
@@ -1,0 +1,35 @@
+package com.redhat.service.smartevents.shard.operator.v2;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.redhat.service.smartevents.shard.operator.v2.providers.NamespaceProvider;
+import com.redhat.service.smartevents.shard.operator.v2.resources.ManagedBridge;
+
+import io.fabric8.kubernetes.api.model.Namespace;
+
+@ApplicationScoped
+public class ManagedBridgeServiceImpl implements ManagedBridgeService {
+
+    @Inject
+    private NamespaceProvider namespaceProvider;
+
+    @Override
+    public void createManagedBridgeResources(ManagedBridge managedBridge) {
+        Namespace namespace = namespaceProvider.fetchOrCreateNamespace(managedBridge);
+
+        /*
+         * Pull in the rest of the logic from BridgeIngressserviceimpl to create the other resources
+         */
+    }
+
+    @Override
+    public void deleteManagedBridgeResources(ManagedBridge managedBridge) {
+
+        /*
+         * Pull in the rest of the logic from BridgeIngressServiceImpl to delete the other resources
+         */
+
+        namespaceProvider.deleteNamespace(managedBridge);
+    }
+}

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/providers/NamespaceProvider.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/providers/NamespaceProvider.java
@@ -1,0 +1,28 @@
+package com.redhat.service.smartevents.shard.operator.v2.providers;
+
+import java.util.Locale;
+
+import com.redhat.service.smartevents.shard.operator.v2.resources.ManagedBridge;
+
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
+
+public interface NamespaceProvider {
+
+    /*
+     * Namespace prefix is "sme" which is short for smartevents
+     */
+    static final String NAMESPACE_NAME_PREFIX = "sme-";
+
+    Namespace fetchOrCreateNamespace(ManagedBridge managedBridge);
+
+    void deleteNamespace(ManagedBridge managedBridge);
+
+    default String getNamespaceName(String bridgeId) {
+        final String sanitizedName = KubernetesResourceUtil.sanitizeName(NAMESPACE_NAME_PREFIX + bridgeId).toLowerCase(Locale.ROOT);
+        if (KubernetesResourceUtil.isValidName(sanitizedName)) {
+            return sanitizedName;
+        }
+        throw new IllegalArgumentException(String.format("Generated namespace name [%s] for ManagedBridge with id [%s] is not a valid kubernetes resource name", sanitizedName, bridgeId));
+    }
+}

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/providers/NamespaceProviderImpl.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/providers/NamespaceProviderImpl.java
@@ -1,0 +1,79 @@
+package com.redhat.service.smartevents.shard.operator.v2.providers;
+
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.redhat.service.smartevents.shard.operator.v2.resources.ManagedBridge;
+import com.redhat.service.smartevents.shard.operator.v2.utils.LabelsBuilder;
+
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+@ApplicationScoped
+public class NamespaceProviderImpl implements NamespaceProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NamespaceProviderImpl.class);
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @Override
+    public Namespace fetchOrCreateNamespace(ManagedBridge managedBridge) {
+        final String name = getNamespaceName(managedBridge.getSpec().getId());
+        final Namespace namespace = kubernetesClient.namespaces().withName(name).get();
+        if (namespace == null) {
+            LOGGER.info("Creating Namespace '{}' for ManagedBridge with id '{}'", name, managedBridge.getSpec().getId());
+            return kubernetesClient.namespaces().createOrReplace(
+                    new NamespaceBuilder()
+                            .withNewMetadata()
+                            .withName(name)
+                            .withLabels(this.createLabels(managedBridge))
+                            .endMetadata()
+                            .build());
+        }
+        return ensureManagedLabels(namespace, managedBridge);
+    }
+
+    private Namespace ensureManagedLabels(final Namespace namespace, final ManagedBridge managedBridge) {
+        final Map<String, String> labels = this.createLabels(managedBridge);
+        boolean mustUpdate = (namespace.getMetadata().getLabels() == null || namespace.getMetadata().getLabels().isEmpty());
+        if (!mustUpdate) {
+            for (Map.Entry<String, String> label : labels.entrySet()) {
+                if (!label.getValue().equals(namespace.getMetadata().getLabels().get(label.getKey()))) {
+                    mustUpdate = true;
+                    break;
+                }
+            }
+        }
+        if (mustUpdate) {
+            LOGGER.info("Updating labels on existing Namespace '{}' for ManagedBridge with id '{}'", namespace.getMetadata().getName(), managedBridge.getSpec().getId());
+            return kubernetesClient.namespaces().withName(
+                    namespace.getMetadata().getName()).edit(n -> new NamespaceBuilder(n).editOrNewMetadata().addToLabels(labels).endMetadata().build());
+        }
+        return namespace;
+    }
+
+    private Map<String, String> createLabels(final ManagedBridge managedBridge) {
+        return new LabelsBuilder()
+                .withCustomerId(managedBridge.getSpec().getCustomerId())
+                .withBridgeId(managedBridge.getSpec().getId())
+                .withBridgeName(managedBridge.getSpec().getName())
+                .buildWithDefaults();
+    }
+
+    @Override
+    public void deleteNamespace(ManagedBridge managedBridge) {
+        String namespaceName = managedBridge.getMetadata().getNamespace();
+        Namespace namespace = kubernetesClient.namespaces().withName(namespaceName).get();
+        if (namespace != null) {
+            kubernetesClient.namespaces().delete(namespace);
+            LOGGER.info("Marked Namespace '{}' for ManagedBridge with id '{}' for deletion.", namespaceName, managedBridge.getSpec().getId());
+        }
+    }
+}

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/DNSConfigurationSpec.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/DNSConfigurationSpec.java
@@ -4,7 +4,7 @@ public class DNSConfigurationSpec {
 
     String host;
 
-    TLSSpec tls;
+    TLSSpec tls = new TLSSpec();
 
     public String getHost() {
         return host;

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridge.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridge.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBridgeStatus> implements Namespaced {
 
     public static final String COMPONENT_NAME = "managed-bridge";
-    public static final String OB_RESOURCE_NAME_PREFIX = "brdg-";
+    public static final String SME_RESOURCE_NAME_PREFIX = "brdg-";
 
     /**
      * Don't use this default constructor!
@@ -67,7 +67,7 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
     }
 
     public static String resolveResourceName(String id) {
-        return OB_RESOURCE_NAME_PREFIX + KubernetesResourceUtil.sanitizeName(id);
+        return SME_RESOURCE_NAME_PREFIX + KubernetesResourceUtil.sanitizeName(id);
     }
 
     public static final class Builder {
@@ -128,6 +128,7 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
             managedBridgeSpec.setCustomerId(customerId);
             managedBridgeSpec.setOwner(owner);
             managedBridgeSpec.setId(bridgeId);
+            managedBridgeSpec.setName(bridgeName);
             managedBridgeSpec.getDnsConfiguration().setHost(host);
 
             ManagedBridge managedBridge = new ManagedBridge();
@@ -140,11 +141,11 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
 
         private void validate() {
             requireNonNull(StringUtils.emptyToNull(this.customerId), "[ManagedBridge] CustomerId can't be null");
+            requireNonNull(StringUtils.emptyToNull(this.namespace), "[ManagedBridge] Namespace can't be null");
+            requireNonNull(StringUtils.emptyToNull(this.owner), "[ManagedBridge] Owner can't be null");
             requireNonNull(StringUtils.emptyToNull(this.bridgeId), "[ManagedBridge] Id can't be null");
             requireNonNull(StringUtils.emptyToNull(this.bridgeName), "[ManagedBridge] Name can't be null");
-            requireNonNull(StringUtils.emptyToNull(this.namespace), "[ManagedBridge] Namespace can't be null");
             requireNonNull(StringUtils.emptyToNull(this.host), "[ManagedBridge] Host can't be null");
         }
     }
-
 }

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridgeSpec.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridgeSpec.java
@@ -6,11 +6,13 @@ public class ManagedBridgeSpec {
 
     private String id;
 
+    private String name;
+
     private String customerId;
 
-    private KNativeBrokerConfigurationSpec kNativeBrokerConfiguration;
+    private KNativeBrokerConfigurationSpec kNativeBrokerConfiguration = new KNativeBrokerConfigurationSpec();
 
-    private DNSConfigurationSpec dnsConfiguration;
+    private DNSConfigurationSpec dnsConfiguration = new DNSConfigurationSpec();
 
     private String owner;
 
@@ -36,6 +38,14 @@ public class ManagedBridgeSpec {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public KNativeBrokerConfigurationSpec getkNativeBrokerConfiguration() {

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/utils/LabelsBuilder.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/utils/LabelsBuilder.java
@@ -1,0 +1,147 @@
+package com.redhat.service.smartevents.shard.operator.v2.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
+
+public class LabelsBuilder {
+
+    private final Map<String, String> labels = new HashMap<>();
+
+    public static final String OPERATOR_NAME = "smartevents-fleet-shard-operator";
+
+    /**
+     * The tool being used to manage the operation of an application
+     */
+    public static final String MANAGED_BY_LABEL = "app.kubernetes.io/managed-by";
+    public static final String CREATED_BY_LABEL = "app.kubernetes.io/created-by";
+    public static final String NAME_LABEL = "app.kubernetes.io/name";
+    public static final String PART_OF_LABEL = "app.kubernetes.io/part-of";
+    public static final String COMPONENT_LABEL = "app.kubernetes.io/component";
+    public static final String VERSION_LABEL = "app.kubernetes.io/version";
+    public static final String INSTANCE_LABEL = "app.kubernetes.io/instance";
+    public static final String CUSTOMER_ID_LABEL = "smartevents.service.redhat.com/customer-id";
+    public static final String BRIDGE_ID_LABEL = "smartevents.service.redhat.com/bridge-id";
+    public static final String BRIDGE_NAME_LABEL = "smartevents.service.redhat.com/bridge-name";
+
+    public static final String RECONCILER_LABEL_SELECTOR = LabelsBuilder.MANAGED_BY_LABEL + "=" + LabelsBuilder.OPERATOR_NAME;
+
+    public static final String PRIMARY_RESOURCE_NAME_LABEL = "operator-sdk/primary-resource-name";
+    public static final String PRIMARY_RESOURCE_NAMESPACE_LABEL = "operator-sdk/primary-resource-namespace";
+
+    /**
+     * Customer Identification label.
+     * Useful for querying objects related to a given customer.
+     */
+    public LabelsBuilder withCustomerId(String customerId) {
+        this.labels.put(CUSTOMER_ID_LABEL, sanitizeAndCheckLabelValue(customerId));
+        return this;
+    }
+
+    public LabelsBuilder withBridgeId(String bridgeId) {
+        this.labels.put(BRIDGE_ID_LABEL, sanitizeAndCheckLabelValue(bridgeId));
+        return this;
+    }
+
+    public LabelsBuilder withBridgeName(String bridgeName) {
+        this.labels.put(BRIDGE_NAME_LABEL, sanitizeAndCheckLabelValue(bridgeName));
+        return this;
+    }
+
+    /**
+     * The controller/user who created this resource
+     */
+    public LabelsBuilder withCreatedBy(String createdBy) {
+        this.labels.put(CREATED_BY_LABEL, sanitizeAndCheckLabelValue(createdBy));
+        return this;
+    }
+
+    /**
+     * The name of the application. Example "mysql".
+     */
+    public LabelsBuilder withAppName(String name) {
+        this.labels.put(NAME_LABEL, sanitizeAndCheckLabelValue(name));
+        return this;
+    }
+
+    /**
+     * The name of a higher level application this one is part of. Example "wordpress".
+     */
+    public LabelsBuilder withPartOf(String partOf) {
+        this.labels.put(PART_OF_LABEL, sanitizeAndCheckLabelValue(partOf));
+        return this;
+    }
+
+    // TODO: in the future we can take this directly from maven version defined in the operator image
+
+    /**
+     * The current version of the application (e.g., a semantic version, revision hash, etc.).
+     */
+    public LabelsBuilder withVersion(String version) {
+        this.labels.put(VERSION_LABEL, sanitizeAndCheckLabelValue(version));
+        return this;
+    }
+
+    /**
+     * A unique name identifying the instance of an application. Example "mysql-abcxyz".
+     */
+    public LabelsBuilder withAppInstance(String instance) {
+        this.labels.put(INSTANCE_LABEL, sanitizeAndCheckLabelValue(instance));
+        return this;
+    }
+
+    /**
+     * A unique name identifying the instance of an application. Example "mysql-abcxyz".
+     */
+    public LabelsBuilder withManagedByOperator() {
+        this.labels.put(MANAGED_BY_LABEL, OPERATOR_NAME);
+        return this;
+    }
+
+    /**
+     * The component within the architecture. Example "database".
+     */
+    public LabelsBuilder withComponent(String component) {
+        this.labels.put(COMPONENT_LABEL, sanitizeAndCheckLabelValue(component));
+        return this;
+    }
+
+    /**
+     * The primary resource name. Example "myresource".
+     */
+    public LabelsBuilder withPrimaryResourceName(String name) {
+        this.labels.put(PRIMARY_RESOURCE_NAME_LABEL, sanitizeAndCheckLabelValue(name));
+        return this;
+    }
+
+    /**
+     * The primary resource namespace. Example "mynamespace".
+     */
+    public LabelsBuilder withPrimaryResourceNamespace(String namespace) {
+        this.labels.put(PRIMARY_RESOURCE_NAMESPACE_LABEL, sanitizeAndCheckLabelValue(namespace));
+        return this;
+    }
+
+    public Map<String, String> buildWithDefaults() {
+        labels.put(MANAGED_BY_LABEL, OPERATOR_NAME);
+        labels.putIfAbsent(CREATED_BY_LABEL, OPERATOR_NAME);
+        return build();
+    }
+
+    public Map<String, String> build() {
+        return labels;
+    }
+
+    /**
+     * @see <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set">Kubernetes Labels - Syntax and Character Set</a>
+     */
+    private String sanitizeAndCheckLabelValue(final String labelValue) {
+        final String sanitized = KubernetesResourceUtil.sanitizeName(labelValue);
+        if (KubernetesResourceUtil.isValidName(sanitized)) {
+            return sanitized;
+        }
+        throw new IllegalArgumentException(String
+                .format("The label value %s is invalid. Label values must be 63 characters or less, begin with [a-z0-9A-Z] and contain only dashes (-), dots (.), or underscores (_)", labelValue));
+    }
+}

--- a/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/providers/NamespaceProviderImplTest.java
+++ b/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/providers/NamespaceProviderImplTest.java
@@ -1,0 +1,131 @@
+package com.redhat.service.smartevents.shard.operator.v2.providers;
+
+import java.util.Map;
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.service.smartevents.shard.operator.v2.resources.ManagedBridge;
+import com.redhat.service.smartevents.shard.operator.v2.utils.LabelsBuilder;
+
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.kubernetes.client.WithOpenShiftTestServer;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@QuarkusTest
+@WithOpenShiftTestServer
+public class NamespaceProviderImplTest {
+
+    @Inject
+    KubernetesClient kubernetesClient;
+
+    @Inject
+    NamespaceProviderImpl namespaceProvider;
+
+    private ManagedBridge createManagedBridge() {
+
+        String id = UUID.randomUUID().toString();
+        String expectedNamespace = namespaceProvider.getNamespaceName(id);
+        ManagedBridge mb = ManagedBridge.fromBuilder()
+                .withBridgeId(id)
+                .withNamespace(expectedNamespace)
+                .withCustomerId(UUID.randomUUID().toString())
+                .withBridgeName(UUID.randomUUID().toString())
+                .withHost(UUID.randomUUID().toString())
+                .withOwner(UUID.randomUUID().toString())
+                .build();
+
+        return mb;
+    }
+
+    @Test
+    public void generateNamespaceName() {
+        ManagedBridge mb = createManagedBridge();
+        String namespaceName = namespaceProvider.getNamespaceName(mb.getSpec().getId());
+        assertThat(namespaceName).isEqualTo(NamespaceProvider.NAMESPACE_NAME_PREFIX + mb.getSpec().getId());
+    }
+
+    @Test
+    public void createNamespace() {
+
+        ManagedBridge mb = createManagedBridge();
+
+        String expectedNamespace = namespaceProvider.getNamespaceName(mb.getSpec().getId());
+        assertThat(kubernetesClient.namespaces().withName(expectedNamespace).get()).isNull();
+
+        Namespace namespace = namespaceProvider.fetchOrCreateNamespace(mb);
+        assertThat(namespace.getMetadata().getName()).isEqualTo(expectedNamespace);
+
+        namespace = kubernetesClient.namespaces().withName(expectedNamespace).get();
+        assertThat(namespace).isNotNull();
+
+        Map<String, String> labels = namespace.getMetadata().getLabels();
+        assertThat(labels.get(LabelsBuilder.BRIDGE_ID_LABEL)).isEqualTo(mb.getSpec().getId());
+        assertThat(labels.get(LabelsBuilder.BRIDGE_NAME_LABEL)).isEqualTo(mb.getSpec().getName());
+        assertThat(labels.get(LabelsBuilder.CUSTOMER_ID_LABEL)).isEqualTo(mb.getSpec().getCustomerId());
+    }
+
+    @Test
+    public void updateNamespaceLabels() {
+
+        ManagedBridge mb = createManagedBridge();
+
+        String expectedNamespace = namespaceProvider.getNamespaceName(mb.getSpec().getId());
+        assertThat(kubernetesClient.namespaces().withName(expectedNamespace).get()).isNull();
+
+        Namespace namespace = namespaceProvider.fetchOrCreateNamespace(mb);
+        assertThat(namespace.getMetadata().getName()).isEqualTo(expectedNamespace);
+
+        namespace = kubernetesClient.namespaces().withName(expectedNamespace).get();
+        assertThat(namespace).isNotNull();
+
+        Map<String, String> labels = namespace.getMetadata().getLabels();
+        assertThat(labels.get(LabelsBuilder.BRIDGE_ID_LABEL)).isEqualTo(mb.getSpec().getId());
+        assertThat(labels.get(LabelsBuilder.BRIDGE_NAME_LABEL)).isEqualTo(mb.getSpec().getName());
+        assertThat(labels.get(LabelsBuilder.CUSTOMER_ID_LABEL)).isEqualTo(mb.getSpec().getCustomerId());
+
+        String newName = "my-new-name";
+        mb.getSpec().setName(newName);
+        namespaceProvider.fetchOrCreateNamespace(mb);
+
+        namespace = kubernetesClient.namespaces().withName(expectedNamespace).get();
+        assertThat(namespace).isNotNull();
+
+        labels = namespace.getMetadata().getLabels();
+        assertThat(labels.get(LabelsBuilder.BRIDGE_ID_LABEL)).isEqualTo(mb.getSpec().getId());
+        assertThat(labels.get(LabelsBuilder.BRIDGE_NAME_LABEL)).isEqualTo(mb.getSpec().getName());
+        assertThat(labels.get(LabelsBuilder.CUSTOMER_ID_LABEL)).isEqualTo(mb.getSpec().getCustomerId());
+    }
+
+    @Test
+    public void deleteNamespace() {
+
+        ManagedBridge mb = createManagedBridge();
+        String expectedName = namespaceProvider.getNamespaceName(mb.getSpec().getId());
+        assertThat(kubernetesClient.namespaces().withName(expectedName).get()).isNull();
+
+        namespaceProvider.fetchOrCreateNamespace(mb);
+
+        Namespace namespace = kubernetesClient.namespaces().withName(expectedName).get();
+        assertThat(namespace).isNotNull();
+        mb.getMetadata().setNamespace(namespace.getMetadata().getName());
+
+        namespaceProvider.deleteNamespace(mb);
+        assertThat(kubernetesClient.namespaces().withName(expectedName).get()).isNull();
+    }
+
+    @Test
+    public void deleteNamespace_namespaceDoesntExist() {
+
+        ManagedBridge mb = createManagedBridge();
+        String expectedName = namespaceProvider.getNamespaceName(mb.getSpec().getId());
+        assertThat(kubernetesClient.namespaces().withName(expectedName).get()).isNull();
+
+        namespaceProvider.deleteNamespace(mb);
+    }
+}


### PR DESCRIPTION
Minor update to the namespace strategy for v2 of the data plane which provisions a namespace-per-bridge rather than a namespace-per-customer

[MGDOBR-1268](https://issues.redhat.com/browse/MGDOBR-1268)

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-1] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
