### PR TITLE
MGDX-284: now push openapi changes to core sdk

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -16,6 +16,7 @@ jobs:
           - "redhat-developer/app-services-sdk-go"
           - "redhat-developer/app-services-sdk-js"
           - "redhat-developer/app-services-sdk-java"
+          - "redhat-developer/app-services-sdk-core"
     runs-on: ubuntu-latest
     if: github.repository == '5733d9e2be6485d52ffa08870cabdee0/sandbox'
     steps:


### PR DESCRIPTION
## Description
This pr enables changes to the openapi spec to be push to the core SDK repo aswell as the other SDKs.

## Jjra
https://issues.redhat.com/browse/MGDX-284

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-XXX] - $clear_explanation_of_what_you_did"
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
