### PR TITLE
MGDOBR-1341: bump java operator sdk 4.0.5 and quarkus 2.13.5 (#1434)" (#1465) - revert - Update kustomization images

### DIFF
--- a/kustomize/base-openshift/kustomization.yaml
+++ b/kustomize/base-openshift/kustomization.yaml
@@ -1,10 +1,10 @@
 images:
 - name: event-bridge-manager
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-manager
-  newTag: 8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  newTag: 5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
-  newTag: ocp-8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  newTag: ocp-5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
 patchesStrategicMerge:
 - manager/patches/deploy.yaml
 - manager/patches/deploy-config.yaml

--- a/kustomize/base-openshift/shard/patches/deploy-config.yaml
+++ b/kustomize/base-openshift/shard/patches/deploy-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
   EVENT_BRIDGE_ISTIO_GATEWAY_NAME: rhose-ingressgateway
   EVENT_BRIDGE_ISTIO_GATEWAY_NAMESPACE: istio-system
   EVENT_BRIDGE_ISTIO_JWT_ISSUER: https://sso.redhat.com/auth/realms/redhat-external

--- a/kustomize/overlays/ci/kustomization.yaml
+++ b/kustomize/overlays/ci/kustomization.yaml
@@ -1,10 +1,10 @@
 images:
 - name: event-bridge-manager
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-manager
-  newTag: 8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  newTag: 5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
-  newTag: k8s-8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  newTag: k8s-5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
 resources:
 - prometheus
 - shard

--- a/kustomize/overlays/ci/shard/patches/deploy-config.yaml
+++ b/kustomize/overlays/ci/shard/patches/deploy-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
   EVENT_BRIDGE_ISTIO_GATEWAY_NAME: rhose-ingressgateway
   EVENT_BRIDGE_ISTIO_GATEWAY_NAMESPACE: istio-system
   EVENT_BRIDGE_ISTIO_JWT_ISSUER: https://sso.redhat.com/auth/realms/redhat-external

--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 images:
 - name: event-bridge-shard-operator
   newName: quay.io/5733d9e2be6485d52ffa08870cabdee0/fleet-shard
-  newTag: ocp-8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  newTag: ocp-5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
 kind: Kustomization
 namespace: event-bridge-prod
 patchesJson6902:

--- a/kustomize/overlays/prod/patches/deploy-config.yaml
+++ b/kustomize/overlays/prod/patches/deploy-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:8e3024d9f489c91789e2d818384f5f02d6e5edfc-jvm
+  EVENT_BRIDGE_EXECUTOR_IMAGE: quay.io/5733d9e2be6485d52ffa08870cabdee0/executor:5e387a360cb27117a8b7bc840013bd4d84e90570-jvm
   EVENT_BRIDGE_ISTIO_GATEWAY_NAME: rhose-ingressgateway
   EVENT_BRIDGE_ISTIO_GATEWAY_NAMESPACE: istio-system
   EVENT_BRIDGE_ISTIO_JWT_ISSUER: https://sso.redhat.com/auth/realms/redhat-external


### PR DESCRIPTION
This Pull request aims to update the kustomization images for the PR MGDOBR-1341: bump java operator sdk 4.0.5 and quarkus 2.13.5 (#1434)" (#1465) - revert