### PR TITLE
Remove v1 dependencies from v2

### DIFF
--- a/shard-operator-parent/shard-operator-core/pom.xml
+++ b/shard-operator-parent/shard-operator-core/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>com.redhat.service.smartevents</groupId>
-      <artifactId>infra-v1</artifactId>
+      <artifactId>infra-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.operatorsdk</groupId>

--- a/shard-operator-parent/shard-operator-v2/pom.xml
+++ b/shard-operator-parent/shard-operator-v2/pom.xml
@@ -69,11 +69,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.redhat.service.smartevents</groupId>
-      <artifactId>processor-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.epam.reportportal</groupId>
       <artifactId>agent-java-junit5</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
No JIRA

I noticed `shard-operator-v2` was including some `v1` dependencies. This PR fixes it.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-XXX] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
