### PR TITLE
MGDOBR-1128: temporarily use the ubi image for CronJob

### DIFF
--- a/app-interface/cronjobs/rhose-stage-prolong.yml
+++ b/app-interface/cronjobs/rhose-stage-prolong.yml
@@ -22,7 +22,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: rhose-prolong-stage
-              image: quay.io/app-sre/rhose-cronjob-runner:1.0
+              image: quay.io/app-sre/ubi8-ubi:8.7
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash


### PR DESCRIPTION
[MGDOBR-1128](https://issues.redhat.com/browse/MGDOBR-1128)

Temporarily use the ubi8 image to workaround the chicken-egg problem with the image build being blocked by missing image. After the image is built successfully by the CI job, this needs to be reverted.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-XXX] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
