### PR TITLE
[MGDOBR-1335] Removed sensitive fields from ManagedBridge CRD

### DIFF
--- a/integration-tests/shard-operator-integration-tests/shard-operator-integration-tests-v2/src/test/resources/features/bridge-resource.feature
+++ b/integration-tests/shard-operator-integration-tests/shard-operator-integration-tests-v2/src/test/resources/features/bridge-resource.feature
@@ -29,16 +29,9 @@ Feature: BridgeResource tests
       owner: user
       dnsConfiguration:
         host: my-bridge
-        tls:
-          key: test
-          certificate: test
-      kNativeBrokerConfiguration:
+      knativeBrokerConfiguration:
         kafkaConfiguration:
           bootstrapServers: ${env.kafka.bootstrap.servers}
-          user: ${env.kafka.ops.client.id}
-          password: ${env.kafka.ops.client.secret}
-          saslMechanism: SASL_SSL
           topic: "${topic.topic1}"
-          securityProtocol: PLAINTEXT
     """
     And the Ingress "test-bridge" is available within 1 minute

--- a/kustomize/base/shard/resources/managedbridges.com.redhat.service.smartevents-v1.yml
+++ b/kustomize/base/shard/resources/managedbridges.com.redhat.service.smartevents-v1.yml
@@ -28,28 +28,30 @@ spec:
                 type: object
               owner:
                 type: string
-              knativeBrokerConfiguration:
-                properties:
-                  kafkaConfiguration:
-                    properties:
-                      saslMechanism:
-                        type: string
-                      numberOfPartitions:
-                        type: integer
-                      bootstrapServers:
-                        type: string
-                      topic:
-                        type: string
-                      numberOfReplicas:
-                        type: integer
-                      securityProtocol:
-                        type: string
-                    type: object
-                type: object
               customerId:
                 type: string
               name:
                 type: string
+              knativeBrokerConfiguration:
+                properties:
+                  kafkaConfiguration:
+                    properties:
+                      bootstrapServers:
+                        type: string
+                      topic:
+                        type: string
+                    type: object
+                type: object
+              sourceConfigurationSpec:
+                properties:
+                  kafkaConfiguration:
+                    properties:
+                      bootstrapServers:
+                        type: string
+                      topic:
+                        type: string
+                    type: object
+                type: object
               generation:
                 type: integer
             type: object
@@ -71,6 +73,7 @@ spec:
                       - "False"
                       - "True"
                       - Unknown
+                      - Failed
                       type: string
                     message:
                       type: string

--- a/kustomize/base/shard/resources/managedbridges.com.redhat.service.smartevents-v1.yml
+++ b/kustomize/base/shard/resources/managedbridges.com.redhat.service.smartevents-v1.yml
@@ -25,31 +25,18 @@ spec:
                 properties:
                   host:
                     type: string
-                  tls:
-                    properties:
-                      key:
-                        type: string
-                      certificate:
-                        type: string
-                    type: object
                 type: object
               owner:
                 type: string
-              customerId:
-                type: string
-              kNativeBrokerConfiguration:
+              knativeBrokerConfiguration:
                 properties:
                   kafkaConfiguration:
                     properties:
                       saslMechanism:
                         type: string
-                      password:
-                        type: string
                       numberOfPartitions:
                         type: integer
                       bootstrapServers:
-                        type: string
-                      user:
                         type: string
                       topic:
                         type: string
@@ -59,6 +46,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              customerId:
+                type: string
               name:
                 type: string
               generation:

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagedBridgeServiceImpl.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagedBridgeServiceImpl.java
@@ -231,6 +231,7 @@ public class ManagedBridgeServiceImpl implements ManagedBridgeService {
          * In addition to that, we can not set the owner references as it is not in the same namespace of the bridgeIngress.
          */
         expected.getMetadata().setNamespace(istioGatewayProvider.getIstioGatewayService().getMetadata().getNamespace());
+        ensureManagedBridgeLabels(managedBridge, expected);
 
         expected.getSpec().setAction("ALLOW");
         expected.getSpec().getRules().forEach(x -> x.getTo().get(0).getOperation().getPaths().set(0, path));
@@ -244,8 +245,6 @@ public class ManagedBridgeServiceImpl implements ManagedBridgeService {
         expected.getSpec().getRules().get(1).setWhen(Collections.singletonList(serviceAccountsAuthPolicy));
         expected.getSpec().getSelector().setMatchLabels(Collections.singletonMap(Constants.BRIDGE_INGRESS_AUTHORIZATION_POLICY_SELECTOR_LABEL,
                 istioGatewayProvider.getIstioGatewayService().getMetadata().getLabels().get(Constants.BRIDGE_INGRESS_AUTHORIZATION_POLICY_SELECTOR_LABEL)));
-
-        ensureManagedBridgeLabels(managedBridge, expected);
 
         AuthorizationPolicy existing = kubernetesClient.resources(AuthorizationPolicy.class)
                 .inNamespace(istioGatewayProvider.getIstioGatewayService().getMetadata().getNamespace()) // https://github.com/istio/istio/issues/37221

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/converters/ManagedBridgeConverter.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/converters/ManagedBridgeConverter.java
@@ -11,8 +11,8 @@ import com.redhat.service.smartevents.infra.v2.api.models.dto.DNSConfigurationDT
 import com.redhat.service.smartevents.infra.v2.api.models.dto.KnativeBrokerConfigurationDTO;
 import com.redhat.service.smartevents.infra.v2.api.models.dto.SourceConfigurationDTO;
 import com.redhat.service.smartevents.shard.operator.v2.resources.DNSConfigurationSpec;
-import com.redhat.service.smartevents.shard.operator.v2.resources.KNativeBrokerConfigurationSpec;
 import com.redhat.service.smartevents.shard.operator.v2.resources.KafkaConfigurationSpec;
+import com.redhat.service.smartevents.shard.operator.v2.resources.KnativeBrokerConfigurationSpec;
 import com.redhat.service.smartevents.shard.operator.v2.resources.ManagedBridge;
 import com.redhat.service.smartevents.shard.operator.v2.resources.SourceConfigurationSpec;
 
@@ -20,7 +20,7 @@ public class ManagedBridgeConverter {
 
     public static ManagedBridge fromBridgeDTOToManageBridge(BridgeDTO bridgeDTO, String namespace) {
         DNSConfigurationSpec dns = fromDNSConfigurationDTOToDNSConfigurationSpec(bridgeDTO.getDnsConfiguration());
-        KNativeBrokerConfigurationSpec kNativeBrokerConfigurationSpec = fromKnativeBrokerConfigurationToKnativeBrokerConfigurationSpec(bridgeDTO.getKnativeBrokerConfiguration());
+        KnativeBrokerConfigurationSpec kNativeBrokerConfigurationSpec = fromKnativeBrokerConfigurationToKnativeBrokerConfigurationSpec(bridgeDTO.getKnativeBrokerConfiguration());
         SourceConfigurationSpec sourceConfigurationSpec = fromSourceConfigurationToSourceConfigurationSpec(bridgeDTO.getSourceConfiguration());
 
         return new ManagedBridge.Builder()
@@ -55,10 +55,10 @@ public class ManagedBridgeConverter {
         return new SourceConfigurationSpec(sourceKafkaConfigurationSpec);
     }
 
-    private static KNativeBrokerConfigurationSpec fromKnativeBrokerConfigurationToKnativeBrokerConfigurationSpec(KnativeBrokerConfigurationDTO knativeBrokerConfiguration) {
+    private static KnativeBrokerConfigurationSpec fromKnativeBrokerConfigurationToKnativeBrokerConfigurationSpec(KnativeBrokerConfigurationDTO knativeBrokerConfiguration) {
         KafkaConnectionDTO knativeBrokerKafkaConnectionDTO = knativeBrokerConfiguration.getKafkaConnection();
         KafkaConfigurationSpec knativeBrokerKafkaConfigurationSpec = fromKafkaConnectionDTOToKafkaConfigurationSpec(knativeBrokerKafkaConnectionDTO);
-        return new KNativeBrokerConfigurationSpec(knativeBrokerKafkaConfigurationSpec);
+        return new KnativeBrokerConfigurationSpec(knativeBrokerKafkaConfigurationSpec);
     }
 
     private static KafkaConfigurationSpec fromKafkaConnectionDTOToKafkaConfigurationSpec(KafkaConnectionDTO kafkaConnectionDTO) {

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/KnativeBrokerConfigurationSpec.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/KnativeBrokerConfigurationSpec.java
@@ -1,14 +1,14 @@
 package com.redhat.service.smartevents.shard.operator.v2.resources;
 
-public class KNativeBrokerConfigurationSpec {
+public class KnativeBrokerConfigurationSpec {
 
     KafkaConfigurationSpec kafkaConfiguration;
 
-    public KNativeBrokerConfigurationSpec() {
+    public KnativeBrokerConfigurationSpec() {
 
     }
 
-    public KNativeBrokerConfigurationSpec(KafkaConfigurationSpec kafkaConfiguration) {
+    public KnativeBrokerConfigurationSpec(KafkaConfigurationSpec kafkaConfiguration) {
         this.kafkaConfiguration = kafkaConfiguration;
     }
 

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridge.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridge.java
@@ -56,7 +56,7 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
         private String bridgeName;
         private String customerId;
         private String owner;
-        private KNativeBrokerConfigurationSpec kNativeBrokerConfigurationSpec;
+        private KnativeBrokerConfigurationSpec knativeBrokerConfigurationSpec;
         private DNSConfigurationSpec dnsConfigurationSpec;
         private long generation;
         private SourceConfigurationSpec sourceConfigurationSpec;
@@ -95,8 +95,8 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
             return this;
         }
 
-        public Builder withKnativeBrokerConfigurationSpec(KNativeBrokerConfigurationSpec kNativeBrokerConfigurationSpec) {
-            this.kNativeBrokerConfigurationSpec = kNativeBrokerConfigurationSpec;
+        public Builder withKnativeBrokerConfigurationSpec(KnativeBrokerConfigurationSpec kNativeBrokerConfigurationSpec) {
+            this.knativeBrokerConfigurationSpec = kNativeBrokerConfigurationSpec;
             return this;
         }
 
@@ -127,7 +127,7 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
             managedBridgeSpec.setId(bridgeId);
             managedBridgeSpec.setName(bridgeName);
             managedBridgeSpec.setDnsConfiguration(this.dnsConfigurationSpec);
-            managedBridgeSpec.setKnativeBrokerConfiguration(this.kNativeBrokerConfigurationSpec);
+            managedBridgeSpec.setKnativeBrokerConfiguration(this.knativeBrokerConfigurationSpec);
             managedBridgeSpec.setGeneration(this.generation);
             managedBridgeSpec.setSourceConfigurationSpec(this.sourceConfigurationSpec);
 
@@ -146,7 +146,7 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
             requireNonNull(StringUtils.emptyToNull(this.bridgeId), "[ManagedBridge] Id can't be null");
             requireNonNull(StringUtils.emptyToNull(this.bridgeName), "[ManagedBridge] Name can't be null");
             requireNonNull(this.dnsConfigurationSpec, "[ManagedBridge] DnsConfigurationSpec can't be null");
-            requireNonNull(this.kNativeBrokerConfigurationSpec, "[ManagedBridge] kNativeBrokerConfigurationSpec can't be null");
+            requireNonNull(this.knativeBrokerConfigurationSpec, "[ManagedBridge] kNativeBrokerConfigurationSpec can't be null");
         }
     }
 }

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridge.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridge.java
@@ -127,7 +127,7 @@ public class ManagedBridge extends CustomResource<ManagedBridgeSpec, ManagedBrid
             managedBridgeSpec.setId(bridgeId);
             managedBridgeSpec.setName(bridgeName);
             managedBridgeSpec.setDnsConfiguration(this.dnsConfigurationSpec);
-            managedBridgeSpec.setkNativeBrokerConfiguration(this.kNativeBrokerConfigurationSpec);
+            managedBridgeSpec.setKnativeBrokerConfiguration(this.kNativeBrokerConfigurationSpec);
             managedBridgeSpec.setGeneration(this.generation);
             managedBridgeSpec.setSourceConfigurationSpec(this.sourceConfigurationSpec);
 

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridgeSpec.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/resources/ManagedBridgeSpec.java
@@ -10,7 +10,7 @@ public class ManagedBridgeSpec {
 
     private String customerId;
 
-    private KNativeBrokerConfigurationSpec kNativeBrokerConfiguration = new KNativeBrokerConfigurationSpec();
+    private KnativeBrokerConfigurationSpec knativeBrokerConfiguration = new KnativeBrokerConfigurationSpec();
 
     private DNSConfigurationSpec dnsConfiguration = new DNSConfigurationSpec();
 
@@ -52,12 +52,12 @@ public class ManagedBridgeSpec {
         this.name = name;
     }
 
-    public KNativeBrokerConfigurationSpec getkNativeBrokerConfiguration() {
-        return kNativeBrokerConfiguration;
+    public KnativeBrokerConfigurationSpec getKnativeBrokerConfiguration() {
+        return knativeBrokerConfiguration;
     }
 
-    public void setkNativeBrokerConfiguration(KNativeBrokerConfigurationSpec kNativeBrokerConfiguration) {
-        this.kNativeBrokerConfiguration = kNativeBrokerConfiguration;
+    public void setKnativeBrokerConfiguration(KnativeBrokerConfigurationSpec knativeBrokerConfiguration) {
+        this.knativeBrokerConfiguration = knativeBrokerConfiguration;
     }
 
     public DNSConfigurationSpec getDnsConfiguration() {
@@ -92,12 +92,12 @@ public class ManagedBridgeSpec {
             return false;
         ManagedBridgeSpec that = (ManagedBridgeSpec) o;
         return generation == that.generation && Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(customerId, that.customerId)
-                && Objects.equals(kNativeBrokerConfiguration, that.kNativeBrokerConfiguration) && Objects.equals(dnsConfiguration, that.dnsConfiguration) && Objects.equals(owner, that.owner)
+                && Objects.equals(knativeBrokerConfiguration, that.knativeBrokerConfiguration) && Objects.equals(dnsConfiguration, that.dnsConfiguration) && Objects.equals(owner, that.owner)
                 && Objects.equals(sourceConfigurationSpec, that.sourceConfigurationSpec);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, customerId, kNativeBrokerConfiguration, dnsConfiguration, owner, generation, sourceConfigurationSpec);
+        return Objects.hash(id, name, customerId, knativeBrokerConfiguration, dnsConfiguration, owner, generation, sourceConfigurationSpec);
     }
 }

--- a/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/converters/ManagedBridgeConverterTest.java
+++ b/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/converters/ManagedBridgeConverterTest.java
@@ -30,7 +30,7 @@ public class ManagedBridgeConverterTest {
         assertThat(managedBridge.getSpec().getOwner()).isEqualTo(bridgeDTO.getOwner());
         assertThat(managedBridge.getSpec().getDnsConfiguration().getHost()).isEqualTo(Fixtures.BRIDGE_HOST);
 
-        KafkaConfigurationSpec kafkaConfiguration = managedBridge.getSpec().getkNativeBrokerConfiguration().getKafkaConfiguration();
+        KafkaConfigurationSpec kafkaConfiguration = managedBridge.getSpec().getKnativeBrokerConfiguration().getKafkaConfiguration();
         assertThat(kafkaConfiguration.getBootstrapServers()).isEqualTo(bridgeDTO.getKnativeBrokerConfiguration().getKafkaConnection().getBootstrapServers());
         assertThat(kafkaConfiguration.getTopic()).isEqualTo(bridgeDTO.getKnativeBrokerConfiguration().getKafkaConnection().getTopic());
     }

--- a/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/converters/ManagedBridgeConverterTest.java
+++ b/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/converters/ManagedBridgeConverterTest.java
@@ -1,0 +1,37 @@
+package com.redhat.service.smartevents.shard.operator.v2.converters;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.redhat.service.smartevents.infra.v2.api.models.OperationType;
+import com.redhat.service.smartevents.infra.v2.api.models.dto.BridgeDTO;
+import com.redhat.service.smartevents.shard.operator.v2.resources.KafkaConfigurationSpec;
+import com.redhat.service.smartevents.shard.operator.v2.resources.ManagedBridge;
+import com.redhat.service.smartevents.shard.operator.v2.utils.Fixtures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ManagedBridgeConverterTest {
+
+    @Test
+    public void fromBridgeDTO() {
+
+        BridgeDTO bridgeDTO = Fixtures.createBridge(OperationType.CREATE);
+        String namespace = UUID.randomUUID().toString();
+
+        ManagedBridge managedBridge = ManagedBridgeConverter.fromBridgeDTOToManageBridge(bridgeDTO, namespace);
+
+        assertThat(managedBridge.getMetadata().getNamespace()).isEqualTo(namespace);
+        assertThat(managedBridge.getSpec().getId()).isEqualTo(bridgeDTO.getId());
+        assertThat(managedBridge.getSpec().getCustomerId()).isEqualTo(bridgeDTO.getCustomerId());
+        assertThat(managedBridge.getSpec().getName()).isEqualTo(bridgeDTO.getName());
+        assertThat(managedBridge.getSpec().getGeneration()).isEqualTo(bridgeDTO.getGeneration());
+        assertThat(managedBridge.getSpec().getOwner()).isEqualTo(bridgeDTO.getOwner());
+        assertThat(managedBridge.getSpec().getDnsConfiguration().getHost()).isEqualTo(Fixtures.BRIDGE_HOST);
+
+        KafkaConfigurationSpec kafkaConfiguration = managedBridge.getSpec().getkNativeBrokerConfiguration().getKafkaConfiguration();
+        assertThat(kafkaConfiguration.getBootstrapServers()).isEqualTo(bridgeDTO.getKnativeBrokerConfiguration().getKafkaConnection().getBootstrapServers());
+        assertThat(kafkaConfiguration.getTopic()).isEqualTo(bridgeDTO.getKnativeBrokerConfiguration().getKafkaConnection().getTopic());
+    }
+}

--- a/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/utils/Fixtures.java
+++ b/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/utils/Fixtures.java
@@ -54,7 +54,7 @@ public class Fixtures {
     }
 
     public static ManagedBridge createManagedBridge(BridgeDTO bridgeDTO, String namespace) {
-        return ManagedBridgeConverter.fromBridgeDTO(bridgeDTO, namespace);
+        return ManagedBridgeConverter.fromBridgeDTOToManageBridge(bridgeDTO, namespace);
     }
 
     public static ProcessorDTO createProcessor(OperationType operation) {

--- a/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/utils/Fixtures.java
+++ b/shard-operator-parent/shard-operator-v2/src/test/java/com/redhat/service/smartevents/shard/operator/v2/utils/Fixtures.java
@@ -54,7 +54,7 @@ public class Fixtures {
     }
 
     public static ManagedBridge createManagedBridge(BridgeDTO bridgeDTO, String namespace) {
-        return ManagedBridgeConverter.fromBridgeDTOToManageBridge(bridgeDTO, namespace);
+        return ManagedBridgeConverter.fromBridgeDTO(bridgeDTO, namespace);
     }
 
     public static ProcessorDTO createProcessor(OperationType operation) {


### PR DESCRIPTION
- Removed sensitive fields from the ManagedBridge CRD and ensured that they are only written to the Secret associated with the Bridge
- Updated the ManagedBridge CRD for our kustomize overlays
- Tested the ManagedBridge converter which was originally incorrectly mapping TLS key and certificate
- Added labels to all resources created by ManagedBridgeService that allow us to easily locate them using kubectl

[MGDOBR-1335](https://issues.redhat.com/browse/MGDOBR-1335)

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-XXX] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
