### PR TITLE
Remove unused exception before v2 Error Catalogue gets polluted.

### DIFF
--- a/infra-parent/infra-v2/src/main/java/com/redhat/service/smartevents/infra/v2/api/exceptions/definitions/platform/UnclassifiedConstraintViolationException.java
+++ b/infra-parent/infra-v2/src/main/java/com/redhat/service/smartevents/infra/v2/api/exceptions/definitions/platform/UnclassifiedConstraintViolationException.java
@@ -1,9 +1,0 @@
-package com.redhat.service.smartevents.infra.v2.api.exceptions.definitions.platform;
-
-public class UnclassifiedConstraintViolationException extends BaseInternalPlatformException {
-
-    public UnclassifiedConstraintViolationException(String message) {
-        super(message);
-    }
-
-}

--- a/infra-parent/infra-v2/src/main/resources/exception/exceptionInfo-v2.json
+++ b/infra-parent/infra-v2/src/main/resources/exception/exceptionInfo-v2.json
@@ -106,11 +106,5 @@
     "id": 18,
     "reason": "An error with AMS occurred.",
     "type": "PLATFORM"
-  },
-  {
-    "exception": "com.redhat.service.smartevents.infra.v2.api.exceptions.definitions.platform.UnclassifiedConstraintViolationException",
-    "id": 19,
-    "reason": "A ConstraintViolation has not been mapped to an ExternalUserException. The raw violation is shown.",
-    "type": "PLATFORM"
   }
 ]


### PR DESCRIPTION
No JIRA.. it's just something I spotted. 

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [x] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [x] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-XXX] - $clear_explanation_of_what_you_did"
- [x] The layers in the `kustomize` folder have been updated accordingly.
- [x] All new functionality is tested
- [x] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
