### PR TITLE
MGDOBR-1421: Disable v2 shard operator sync and v2 e2e tests

### DIFF
--- a/integration-tests/manager-integration-tests/manager-integration-tests-v2/src/test/java/com/redhat/service/smartevents/integration/tests/v2/RunCucumberTest.java
+++ b/integration-tests/manager-integration-tests/manager-integration-tests-v2/src/test/java/com/redhat/service/smartevents/integration/tests/v2/RunCucumberTest.java
@@ -13,7 +13,7 @@ import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 @Suite
 @IncludeEngines("cucumber")
 @SelectClasspathResource("features")
-@ConfigurationParameter(key = Constants.FILTER_TAGS_PROPERTY_NAME, value = "not @ansibleaction")
+@ConfigurationParameter(key = Constants.FILTER_TAGS_PROPERTY_NAME, value = "not @disabled")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME,
         value = "com.redhat.service.smartevents.integration.tests.steps,com.redhat.service.smartevents.integration.tests.resources,com.redhat.service.smartevents.integration.tests.v2.steps")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "com.redhat.service.smartevents.integration.tests.cucumber.TestCaseFileLogger,com.epam.reportportal.cucumber.ScenarioReporter")

--- a/integration-tests/manager-integration-tests/manager-integration-tests-v2/src/test/resources/features/bridge.feature
+++ b/integration-tests/manager-integration-tests/manager-integration-tests-v2/src/test/resources/features/bridge.feature
@@ -1,5 +1,6 @@
 Feature: Bridge tests
 
+  @disabled
   Scenario: Create a Bridge and Delete a Bridge
     Given authenticate against Manager
     When create a new Bridge "mybridge" in cloud provider "aws" and region "us-east-1"

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagerSyncService.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagerSyncService.java
@@ -19,14 +19,14 @@ public class ManagerSyncService {
     @Inject
     ManagedProcessorSyncService managedProcessorSyncService;
 
-    @Scheduled(every = "30s", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(every = "event-bridge.scheduler.v2.expr", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     public void syncUpdatesFromManager() {
         LOGGER.debug("Fetching updates from Manager for Bridges to deploy and delete");
         managedBridgeSyncService.syncManagedBridgeWithManager();
         managedProcessorSyncService.syncManagedProcessorWithManager();
     }
 
-    @Scheduled(every = "30s", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(every = "event-bridge.scheduler.v2.expr", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     public void syncStatusBackToManager() {
         LOGGER.debug("Sending back status from Operator to Manager");
         managedBridgeSyncService.syncManagedBridgeStatusBackToManager();

--- a/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagerSyncService.java
+++ b/shard-operator-parent/shard-operator-v2/src/main/java/com/redhat/service/smartevents/shard/operator/v2/ManagerSyncService.java
@@ -19,14 +19,14 @@ public class ManagerSyncService {
     @Inject
     ManagedProcessorSyncService managedProcessorSyncService;
 
-    @Scheduled(every = "event-bridge.scheduler.v2.expr", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(cron = "${event-bridge.scheduler.cron.v2.expr}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     public void syncUpdatesFromManager() {
         LOGGER.debug("Fetching updates from Manager for Bridges to deploy and delete");
         managedBridgeSyncService.syncManagedBridgeWithManager();
         managedProcessorSyncService.syncManagedProcessorWithManager();
     }
 
-    @Scheduled(every = "event-bridge.scheduler.v2.expr", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    @Scheduled(cron = "${event-bridge.scheduler.cron.v2.expr}", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     public void syncStatusBackToManager() {
         LOGGER.debug("Sending back status from Operator to Manager");
         managedBridgeSyncService.syncManagedBridgeStatusBackToManager();

--- a/shard-operator-parent/shard-operator-v2/src/main/resources/application.properties
+++ b/shard-operator-parent/shard-operator-v2/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 # Configuration of polling and timeout operations for resources relating to a ManagedBridge instance
 event-bridge.managed-bridge.poll.interval-milliseconds=5000
 
-event-bridge.scheduler.v2.expr=${EVENT_BRIDGE_SCHEDULER_V2_EXPR:disabled}
+event-bridge.scheduler.cron.v2.expr=${EVENT_BRIDGE_SCHEDULER_CRON_V2_EXPR:disabled}
 
-%dev.event-bridge.scheduler.v2.expr=30s
+%dev.event-bridge.scheduler.cron.v2.expr=* * * * *

--- a/shard-operator-parent/shard-operator-v2/src/main/resources/application.properties
+++ b/shard-operator-parent/shard-operator-v2/src/main/resources/application.properties
@@ -1,2 +1,6 @@
 # Configuration of polling and timeout operations for resources relating to a ManagedBridge instance
 event-bridge.managed-bridge.poll.interval-milliseconds=5000
+
+event-bridge.scheduler.v2.expr=${EVENT_BRIDGE_SCHEDULER_V2_EXPR:disabled}
+
+%dev.event-bridge.scheduler.v2.expr=30s


### PR DESCRIPTION
[MGDOBR-1421](https://issues.redhat.com/browse/MGDOBR-1421)

RIP V2

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-XXX] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
