### PR TITLE
MGDOBR-1128: set OCM_CONFIG in the CronJob image

### DIFF
--- a/app-interface/app_sre_cronjob_runner_build_push.sh
+++ b/app-interface/app_sre_cronjob_runner_build_push.sh
@@ -2,7 +2,7 @@
 
 IMAGE_NAME="quay.io/app-sre/rhose-cronjob-runner"
 # the RHOSE CronJob Runner is stable, we do not need to push a new image for every commit
-IMAGE_TAG="1.1"
+IMAGE_TAG="1.2"
 
 docker build -f app-interface/cronjobs/Dockerfile.cronjobs -t "${IMAGE_NAME}:${IMAGE_TAG}"  .
 docker tag "${IMAGE_NAME}:${IMAGE_TAG}" "${IMAGE_NAME}:latest"

--- a/app-interface/cronjobs/Dockerfile.cronjobs
+++ b/app-interface/cronjobs/Dockerfile.cronjobs
@@ -3,6 +3,6 @@ FROM registry.access.redhat.com/ubi8/ubi:8.7
 RUN dnf copr enable -y ocm/tools
 RUN dnf install -y ocm-cli jq
 
-RUN useradd -ms /bin/bash cronjobuser
-USER cronjobuser
-WORKDIR /home/cronjobuser
+RUN mkdir /ocm
+RUN chmod 775 /ocm
+ENV OCM_CONFIG=/ocm/ocm.json

--- a/app-interface/cronjobs/rhose-stage-prolong.yml
+++ b/app-interface/cronjobs/rhose-stage-prolong.yml
@@ -24,7 +24,7 @@ spec:
           serviceAccountName: registry-rhose-appsre
           containers:
             - name: rhose-prolong-stage
-              image: quay.io/app-sre/rhose-cronjob-runner:1.1
+              image: quay.io/app-sre/rhose-cronjob-runner:1.2
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/bash


### PR DESCRIPTION
[MGDOBR-1128](https://issues.redhat.com/browse/MGDOBR-1128)

Set OCM_CONFIG in the CronJob image to avoid ocm trying to store data in root.

## PR owner checklist

Please make sure that your PR meets the following requirements:

- [ ] Your code is properly formatted according to [this configuration](https://github.com/kiegroup/kogito-runtimes/tree/main/kogito-build/kogito-ide-config).  
  *Run `mvn clean verify -DskipTests` so that imports are correctly set.*
- [ ] Your commit messages are clear and reference the JIRA issue e.g: "[MGDOBR-XXX] - $clear_explanation_of_what_you_did"
- [ ] The layers in the `kustomize` folder have been updated accordingly.
- [ ] All new functionality is tested
- [ ] Pull Request title is properly formatted: `MGDOBR-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

## PR reviewer(s) checklist

- [ ] Check if code and Github action workflows have been modified and if the modification is safe
- [ ] If the modification is safe, add the `safe to test` label

<details>
<summary>
How to trigger pipelines and use the bots:
</summary>

- <b>Run the end to end pipeline</b>  
  Annotate the pull request with the label: `safe to test`. If you want to run the pipeline again, remove and add it again.

- <b>Rebase the pull request</b>  
  Comment with: `/rebase`.
- <b>Deploy BOT</b>
  Comment with `/deploy <dev,stable> when the PR has been merged to deploy to a target environment.

</details>
